### PR TITLE
commented out 1 line of code

### DIFF
--- a/drivers/adodb-sybase.inc.php
+++ b/drivers/adodb-sybase.inc.php
@@ -39,6 +39,7 @@ class ADODB_sybase extends ADOConnection {
 	var $sysDate = 'GetDate()';
 	var $leftOuter = '*=';
 	var $rightOuter = '=*';
+	var $charSet = 'iso_1'; // knbknb 20130819
 
 	function ADODB_sybase()
 	{
@@ -125,11 +126,12 @@ class ADODB_sybase extends ADOConnection {
 
 		if ($this->charSet) {
  			$this->_connectionID = sybase_connect($argHostname,$argUsername,$argPassword, $this->charSet);
-       	} else {
-       		$this->_connectionID = sybase_connect($argHostname,$argUsername,$argPassword);
-       	}
+       		} else {
+       			$this->_connectionID = sybase_connect($argHostname,$argUsername,$argPassword);
+       		}
 
-		$this->_connectionID = sybase_connect($argHostname,$argUsername,$argPassword);
+		// this line is redundant, the if-statement block above has already handled this case
+		// $this->_connectionID = sybase_connect($argHostname,$argUsername,$argPassword);
 		if ($this->_connectionID === false) return false;
 		if ($argDatabasename) return $this->SelectDB($argDatabasename);
 		return true;


### PR DESCRIPTION
in the _connect() method of  file drivers/adodb-sybase.inc.php
there is an if block which tries to call sybase_connect() in both branches of the block.
 if ($this->charSet) {} else {} 

After the if/else block there is a third call to sybase_connect() which is redundant. I've simply commented out this line.

the 
var $charSet declaration should be added because there is a test for the presence of this variable in the function _connect()
Maybe it is handled in the base class, maybe it's passed in as a new property by the caller,  autovivified by dynamic expansion of the class.

  at the top is optional. 
i've set it to  "iso_1" because it is reasonable for many but maybe it's not generic enough. 
