### PR TITLE
Updated ADODB_mssql_n to support calling of stored procedures

### DIFF
--- a/drivers/adodb-mssql_n.inc.php
+++ b/drivers/adodb-mssql_n.inc.php
@@ -60,7 +60,9 @@ class ADODB_mssql_n extends ADODB_mssql {
 
 	function _query($sql,$inputarr=false)
 	{
-        $sql = $this->_appendN($sql);
+		if (!is_array($sql)) {
+        		$sql = $this->_appendN($sql);
+		}
 		return ADODB_mssql::_query($sql,$inputarr);
 	}
 


### PR DESCRIPTION
Method _query in ADODB_mssql_n was unable to handle calls to stored procedures.

function _query($sql,$inputarr=false){
$sql = $this->_appendN($sql);
return ADODB_mssql::_query($sql,$inputarr);
}

It expected $sql to always be a string, but in case of a stored procedure it was an array.