### PR TITLE
adodb-session2.php open method fails when it shouldn't

### DIFF
--- a/session/adodb-session2.php
+++ b/session/adodb-session2.php
@@ -581,6 +581,8 @@ class ADODB_Session {
 			} else {
 				$ok = $conn->Connect($host, $user, $password, $database);
 			}
+		} else {
+			$ok = true; // $conn->_connectionID is set after call to ADONewConnection
 		}
 
 		if ($ok) $GLOBALS['ADODB_SESS_CONN'] = $conn;


### PR DESCRIPTION
Set value of $ok variable to true when ADONewConnection call works on line 566.

resolves #42
