### PR TITLE
PDO minor fixes

### DIFF
--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -438,12 +438,12 @@ class ADODB_pdo_base extends ADODB_pdo {
 		return $ret;
 	}
 
-	function MetaTables()
+	function MetaTables($ttype=false,$showSchema=false,$mask=false)
 	{
 		return false;
 	}
 
-	function MetaColumns()
+	function MetaColumns($table,$normalize=true)
 	{
 		return false;
 	}

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -179,7 +179,7 @@ class ADODB_pdo extends ADOConnection {
 	function Concat()
 	{
 		$args = func_get_args();
-		if(method_exists($this->_driver, 'Concat'))
+		if(isset($this->_driver) && method_exists($this->_driver, 'Concat')) 
 			return call_user_func_array(array($this->_driver, 'Concat'), $args);
 
 		if (PHP_VERSION >= 5.3) return call_user_func_array('parent::Concat', $args);
@@ -266,7 +266,7 @@ class ADODB_pdo extends ADOConnection {
 
 	function SetTransactionMode($transaction_mode)
 	{
-		if(method_exists($this->_driver, 'SetTransactionMode'))
+		if(isset($this->_driver) && method_exists($this->_driver, 'SetTransactionMode')) 
 			return $this->_driver->SetTransactionMode($transaction_mode);
 
 		return parent::SetTransactionMode($seqname);
@@ -274,7 +274,7 @@ class ADODB_pdo extends ADOConnection {
 
 	function BeginTrans()
 	{
-		if(method_exists($this->_driver, 'BeginTrans'))
+		if(isset($this->_driver) && method_exists($this->_driver, 'BeginTrans')) 
 			return $this->_driver->BeginTrans();
 
 		if (!$this->hasTransactions) return false;
@@ -287,7 +287,7 @@ class ADODB_pdo extends ADOConnection {
 
 	function CommitTrans($ok=true)
 	{
-		if(method_exists($this->_driver, 'CommitTrans'))
+		if(isset($this->_driver) && method_exists($this->_driver, 'CommitTrans')) 
 			return $this->_driver->CommitTrans($ok);
 
 		if (!$this->hasTransactions) return false;
@@ -303,7 +303,7 @@ class ADODB_pdo extends ADOConnection {
 
 	function RollbackTrans()
 	{
-		if(method_exists($this->_driver, 'RollbackTrans'))
+		if(isset($this->_driver) && method_exists($this->_driver, 'RollbackTrans')) 
 			return $this->_driver->RollbackTrans();
 
 		if (!$this->hasTransactions) return false;
@@ -334,7 +334,7 @@ class ADODB_pdo extends ADOConnection {
 
 	function CreateSequence($seqname='adodbseq',$startID=1)
 	{
-		if(method_exists($this->_driver, 'CreateSequence'))
+		if(isset($this->_driver) && method_exists($this->_driver, 'CreateSequence')) 
 			return $this->_driver->CreateSequence($seqname, $startID);
 
 		return parent::CreateSequence($seqname, $startID);
@@ -342,7 +342,7 @@ class ADODB_pdo extends ADOConnection {
 
 	function DropSequence($seqname='adodbseq')
 	{
-		if(method_exists($this->_driver, 'DropSequence'))
+		if(isset($this->_driver) && method_exists($this->_driver, 'DropSequence')) 
 			return $this->_driver->DropSequence($seqname);
 
 		return parent::DropSequence($seqname);
@@ -350,7 +350,7 @@ class ADODB_pdo extends ADOConnection {
 
 	function GenID($seqname='adodbseq',$startID=1)
 	{
-		if(method_exists($this->_driver, 'GenID'))
+		if(isset($this->_driver) && method_exists($this->_driver, 'GenID')) 
 			return $this->_driver->GenID($seqname, $startID);
 
 		return parent::GenID($seqname, $startID);


### PR DESCRIPTION
The inconsistent method parameters for MetaColumns and MetaTables just cause NOTICEs if error reporting is turned up high enough.

The gating around $this->_driver is probably to #56 but admittedly I don't know what the underlying problem is. I was simply trying to avoid the fatal error that occurs if the uninitialized method is treated as an object.