### PR TITLE
Fix when several columns were altered at the same time.

### DIFF
--- a/datadict/datadict-postgres.inc.php
+++ b/datadict/datadict-postgres.inc.php
@@ -190,8 +190,8 @@ class ADODB2_postgres extends ADODB_DataDict {
 			$sql = array();
 			list($lines,$pkey) = $this->_GenFields($flds);
 			$set_null = false;
-			$alter = 'ALTER TABLE ' . $tabname . $this->alterCol . ' ';
 			foreach($lines as $v) {
+				$alter = 'ALTER TABLE ' . $tabname . $this->alterCol . ' ';
 				if ($not_null = preg_match('/NOT NULL/i',$v)) {
 					$v = preg_replace('/NOT NULL/i','',$v);
 				}


### PR DESCRIPTION
The loop was generating SQL like
ALTER TABLE sometable ALTER COLUMN col1 ...
ALTER TABLE sometable ALTER COLUMN col1col2 ...
ALTER TABLE sometable ALTER COLUMN col1col2col3 ...
when argument $flds contained more than 1 column to modify.