### PR TITLE
Handle partially SERIAL datatype.

### DIFF
--- a/datadict/datadict-postgres.inc.php
+++ b/datadict/datadict-postgres.inc.php
@@ -142,6 +142,18 @@ class ADODB2_postgres extends ADODB_DataDict {
 				$sql[] = $alter . str_replace('DEFAULT '.$default,'',$v);
 				$sql[] = 'UPDATE '.$tabname.' SET '.$colname.'='.$default;
 				$sql[] = 'ALTER TABLE '.$tabname.' ALTER COLUMN '.$colname.' SET DEFAULT ' . $default;
+			}
+			// SERIAL is not a true type in PostgreSQL and is only allowed when creating a new table.
+			// See http://www.postgresql.org/docs/9.4/static/datatype-numeric.html, 8.1.4. Serial Types.
+			elseif (preg_match('/^([^ ]+) .*SERIAL/i',$v,$matches)) {
+			       list(,$colname,$default) = $matches;
+			       $sql[] = 'CREATE SEQUENCE '.$tabname.'_'.$colname.'_seq';
+			       $sql[] = $alter.$colname.' INTEGER';
+			       $sql[] = 'ALTER SEQUENCE '.$tabname.'_'.$colname.'_seq OWNED BY '.$tabname.'.'.$colname;
+			       $sql[] = 'UPDATE '.$tabname.' SET '.$colname.' = nextval(\''.$tabname.'_'.$colname.'_seq\')';
+			       $sql[] = 'ALTER TABLE '.$tabname.' ALTER COLUMN '.$colname.' SET DEFAULT nextval(\''.$tabname.'_'.$colname.'_seq\')';
+			       $sql[] = 'ALTER TABLE '.$tabname.' ALTER COLUMN '.$colname.' SET NOT NULL';
+			       $not_null = false;
 			} else {
 				$sql[] = $alter . $v;
 			}
@@ -204,7 +216,12 @@ class ADODB2_postgres extends ADODB_DataDict {
 					// the default value
 					$v = preg_replace('/(?<!DEFAULT)\sNULL/i','',$v);
 				}
-
+				// SERIAL is not a true type in PostgreSQL and is only allowed when creating a new table.
+				// See http://www.postgresql.org/docs/9.4/static/datatype-numeric.html, 8.1.4. Serial Types.
+				// Just skip, no failsafe solution found yet.
+				if (preg_match('/SERIAL/i',$v)) {
+					continue;
+				}
 				if (preg_match('/^([^ ]+) .*DEFAULT (\'[^\']+\'|\"[^\"]+\"|[^ ]+)/',$v,$matches)) {
 					$existing = $this->MetaColumns($tabname);
 					list(,$colname,$default) = $matches;


### PR DESCRIPTION
This is an alternative approach to pull request "Avoid use of SERIAL in ALTER TABLE with PostgreSQL #11". It has the benefit of not touching anything not PostgreSQL-specific and handles at least the adding of SERIAL columns. Not modifying them, unfortunately.