### PR TITLE
mssql datetime2 metatype mapping

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -4015,6 +4015,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 			'TIME' => 'T',
 			'TIMESTAMP' => 'T',
 			'DATETIME' => 'T',
+			'DATETIME2' => 'T',
 			'TIMESTAMPTZ' => 'T',
 			'T' => 'T',
 			'TIMESTAMP WITHOUT TIME ZONE' => 'T', // postgresql


### PR DESCRIPTION
Adds the mssql datatype datetime2 to the metatype mapping.  Prevents date time errors caused by the field being treated as a long.