### PR TITLE
Remove PGSQL legacy function calls, and switch to using proper ones where applicable.

### DIFF
--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -16,7 +16,6 @@ $ADODB_INCLUDED_LIB = 1;
 */
 
 function adodb_strip_order_by($sql)
-{
 	$rez = preg_match('/(\sORDER\s+BY\s(?:[^)](?!LIMIT))*)/is', $sql, $arr);
 	if ($arr)
 		if (strpos($arr[1], '(') !== false) {

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -421,8 +421,11 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
 		}
 	} else {
 		// now replace SELECT ... FROM with SELECT COUNT(*) FROM
-		$rewritesql = preg_replace(
-					'/^\s*SELECT\s.*\s+FROM\s/Uis','SELECT COUNT(*) FROM ',$sql);
+		if ( strpos($sql, '_ADODB_COUNT') !== FALSE ) {
+			$rewritesql = preg_replace('/^\s*?SELECT\s+_ADODB_COUNT(.*)_ADODB_COUNT\s/is','SELECT COUNT(*) ',$sql);
+		} else {
+			$rewritesql = preg_replace('/^\s*?SELECT\s.*?\s+(.*?)\s+FROM\s/is','SELECT COUNT(*) FROM ',$sql);
+		}
 		// fix by alexander zhukov, alex#unipack.ru, because count(*) and 'order by' fails
 		// with mssql, access and postgresql. Also a good speedup optimization - skips sorting!
 		// also see http://phplens.com/lens/lensforum/msgs.php?id=12752

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -16,6 +16,7 @@ $ADODB_INCLUDED_LIB = 1;
 */
 
 function adodb_strip_order_by($sql)
+{
 	$rez = preg_match('/(\sORDER\s+BY\s(?:[^)](?!LIMIT))*)/is', $sql, $arr);
 	if ($arr)
 		if (strpos($arr[1], '(') !== false) {

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1122,8 +1122,13 @@ if (!defined('_ADODB_LAYER')) {
 		return $ret;
 	}
 
+	//Strips keyword used to help generate SELECT COUNT(*) queries from SQL if it exists.
+	function adodb_strip_count_keyword( $sql ) {
+		return ADODB_str_replace( '_ADODB_COUNT', '', $sql );
+	}
 
 	function _Execute($sql,$inputarr=false) {
+		$sql = $this->adodb_strip_count_keyword( $sql );
 		if ($this->debug) {
 			global $ADODB_INCLUDED_LIB;
 			if (empty($ADODB_INCLUDED_LIB)) {

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -3635,6 +3635,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		}
 
 		if ($rowNumber < 0) {
+			$this->EOF = true;
 			return false;
 		}
 

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -86,17 +86,13 @@ if (!defined('_ADODB_LAYER')) {
 	// ********************************************************
 
 
-
-
-		define('ADODB_BAD_RS','<p>Bad $rs in %s. Connection or SQL invalid. Try using $connection->debug=true;</p>');
+		if (!defined('ADODB_BAD_RS')) define('ADODB_BAD_RS','<p>Bad $rs in %s. Connection or SQL invalid. Try using $connection->debug=true;</p>');
 
 	// allow [ ] @ ` " and . in table names
-		define('ADODB_TABLE_REGEX','([]0-9a-z_\:\"\`\.\@\[-]*)');
+		if (!defined('ADODB_TABLE_REGEX')) define('ADODB_TABLE_REGEX','([]0-9a-z_\:\"\`\.\@\[-]*)');
 
 	// prefetching used by oracle
-		if (!defined('ADODB_PREFETCH_ROWS')) {
-			define('ADODB_PREFETCH_ROWS',10);
-		}
+		if (!defined('ADODB_PREFETCH_ROWS')) define('ADODB_PREFETCH_ROWS',10);
 
 
 	/*
@@ -111,23 +107,24 @@ if (!defined('_ADODB_LAYER')) {
 		define('ADODB_ASSOC_CASE_UPPER', 1);
 		define('ADODB_ASSOC_CASE_NATIVE', 2);
 
-		define('ADODB_FETCH_DEFAULT',0);
-		define('ADODB_FETCH_NUM',1);
-		define('ADODB_FETCH_ASSOC',2);
-		define('ADODB_FETCH_BOTH',3);
+		if (!defined('ADODB_FETCH_DEFAULT')) define('ADODB_FETCH_DEFAULT',0);
+		if (!defined('ADODB_FETCH_NUM')) define('ADODB_FETCH_NUM',1);
+		if (!defined('ADODB_FETCH_ASSOC')) define('ADODB_FETCH_ASSOC',2);
+		if (!defined('ADODB_FETCH_BOTH')) define('ADODB_FETCH_BOTH',3);
 
-		if (!defined('TIMESTAMP_FIRST_YEAR')) {
-			define('TIMESTAMP_FIRST_YEAR',100);
-		}
+		if (!defined('TIMESTAMP_FIRST_YEAR')) define('TIMESTAMP_FIRST_YEAR',100);
 
+		if (!defined('ADODB_PHPVER')) {
 		// PHP's version scheme makes converting to numbers difficult - workaround
-		$_adodb_ver = (float) PHP_VERSION;
-		if ($_adodb_ver >= 5.2) {
-			define('ADODB_PHPVER',0x5200);
-		} else if ($_adodb_ver >= 5.0) {
-			define('ADODB_PHPVER',0x5000);
-		} else
-			die("PHP5 or later required. You are running ".PHP_VERSION);
+			$_adodb_ver = (float) PHP_VERSION;
+			if ($_adodb_ver >= 5.2) {
+				define('ADODB_PHPVER',0x5200);
+			} else if ($_adodb_ver >= 5.0) {
+				define('ADODB_PHPVER',0x5000);
+			} else {
+				die("PHP5 or later required. You are running ".PHP_VERSION);
+			}
+		}
 	}
 
 

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -3634,6 +3634,10 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 			}
 		}
 
+		if ($rowNumber < 0) {
+			return false;
+		}
+
 		if ($this->canSeek) {
 			if ($this->_seek($rowNumber)) {
 				$this->_currentRow = $rowNumber;

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -68,8 +68,8 @@ class ADODB_postgres64 extends ADOConnection{
 		select viewname,'V' from pg_views where viewname not like 'pg\_%'";
 	//"select tablename from pg_tables where tablename not like 'pg_%' order by 1";
 	var $isoDates = true; // accepts dates in ISO format
-	var $sysDate = "CURRENT_DATE";
-	var $sysTimeStamp = "CURRENT_TIMESTAMP";
+	var $sysDate = 'CURRENT_DATE';
+	var $sysTimeStamp = 'CURRENT_TIMESTAMP';
 	var $blobEncodeType = 'C';
 	var $metaColumnsSQL = "SELECT a.attname,t.typname,a.attlen,a.atttypmod,a.attnotnull,a.atthasdef,a.attnum
 		FROM pg_class c, pg_attribute a,pg_type t
@@ -101,8 +101,8 @@ class ADODB_postgres64 extends ADOConnection{
 	var $hasMoveFirst = true;
 	var $hasGenID = true;
 	var $_genIDSQL = "SELECT NEXTVAL('%s')";
-	var $_genSeqSQL = "CREATE SEQUENCE %s START %s";
-	var $_dropSeqSQL = "DROP SEQUENCE %s";
+	var $_genSeqSQL = 'CREATE SEQUENCE %s START %s';
+	var $_dropSeqSQL = 'DROP SEQUENCE %s';
 	var $metaDefaultsSQL = "SELECT d.adnum as num, d.adsrc as def from pg_attrdef d, pg_class c where d.adrelid=c.oid and c.relname='%s' order by d.adnum";
 	var $random = 'random()';		/// random function
 	var $autoRollback = true; // apparently pgsql does not autorollback properly before php 4.3.4
@@ -139,13 +139,13 @@ class ADODB_postgres64 extends ADOConnection{
 
 	function IfNull( $field, $ifNull )
 	{
-		return " coalesce($field, $ifNull) ";
+		return ' coalesce($field, $ifNull) ';
 	}
 
 	// get the last id - never tested
 	function pg_insert_id($tablename,$fieldname)
 	{
-		$result=pg_exec($this->_connectionID, "SELECT last_value FROM ${tablename}_${fieldname}_seq");
+		$result=pg_exec($this->_connectionID, 'SELECT last_value FROM ${tablename}_${fieldname}_seq');
 		if ($result) {
 			$arr = @pg_fetch_row($result,0);
 			pg_free_result($result);
@@ -163,7 +163,7 @@ a different OID if a database must be reloaded. */
 		if (!is_resource($this->_resultid) || get_resource_type($this->_resultid) !== 'pgsql result') return false;
 		$oid = pg_getlastoid($this->_resultid);
 		// to really return the id, we need the table and column-name, else we can only return the oid != id
-		return empty($table) || empty($column) ? $oid : $this->GetOne("SELECT $column FROM $table WHERE oid=".(int)$oid);
+		return empty($table) || empty($column) ? $oid : $this->GetOne('SELECT $column FROM $table WHERE oid='.(int)$oid);
 	}
 
 // I get this error with PHP before 4.0.6 - jlim
@@ -180,13 +180,13 @@ a different OID if a database must be reloaded. */
 	{
 		if ($this->transOff) return true;
 		$this->transCnt += 1;
-		return @pg_Exec($this->_connectionID, "begin ".$this->_transmode);
+		return @pg_Exec($this->_connectionID, 'begin '.$this->_transmode);
 	}
 
 	function RowLock($tables,$where,$col='1 as adodbignore')
 	{
 		if (!$this->transCnt) $this->BeginTrans();
-		return $this->GetOne("select $col from $tables where $where for update");
+		return $this->GetOne('select $col from $tables where $where for update');
 	}
 
 	// returns true/false.
@@ -196,7 +196,7 @@ a different OID if a database must be reloaded. */
 		if (!$ok) return $this->RollbackTrans();
 
 		$this->transCnt -= 1;
-		return @pg_Exec($this->_connectionID, "commit");
+		return @pg_Exec($this->_connectionID, 'commit');
 	}
 
 	// returns true/false
@@ -204,7 +204,7 @@ a different OID if a database must be reloaded. */
 	{
 		if ($this->transOff) return true;
 		$this->transCnt -= 1;
-		return @pg_Exec($this->_connectionID, "rollback");
+		return @pg_Exec($this->_connectionID, 'rollback');
 	}
 
 	function MetaTables($ttype=false,$showSchema=false,$mask=false)
@@ -354,7 +354,7 @@ a different OID if a database must be reloaded. */
 	*/
 	function UpdateBlobFile($table,$column,$path,$where,$blobtype='BLOB')
 	{
-		pg_exec ($this->_connectionID, "begin");
+		pg_exec ($this->_connectionID, 'begin');
 
 		$fd = fopen($path,'r');
 		$contents = fread($fd,filesize($path));
@@ -366,7 +366,7 @@ a different OID if a database must be reloaded. */
 		pg_lo_close($handle);
 
 		// $oid = pg_lo_import ($path);
-		pg_exec($this->_connectionID, "commit");
+		pg_exec($this->_connectionID, 'commit');
 		$rs = ADOConnection::UpdateBlob($table,$column,$oid,$where,$blobtype);
 		$rez = !empty($rs);
 		return $rez;
@@ -382,9 +382,9 @@ a different OID if a database must be reloaded. */
 	*/
 	function BlobDelete( $blob )
 	{
-		pg_exec ($this->_connectionID, "begin");
+		pg_exec($this->_connectionID, 'begin');
 		$result = @pg_lo_unlink($blob);
-		pg_exec ($this->_connectionID, "commit");
+		pg_exec($this->_connectionID, 'commit');
 		return( $result );
 	}
 
@@ -413,16 +413,16 @@ a different OID if a database must be reloaded. */
 	{
 		if (!$this->GuessOID($blob)) return $blob;
 
-		if ($hastrans) @pg_exec($this->_connectionID,"begin");
+		if ($hastrans) @pg_exec($this->_connectionID,'begin');
 		$fd = @pg_lo_open($this->_connectionID,$blob,"r");
 		if ($fd === false) {
-			if ($hastrans) @pg_exec($this->_connectionID,"commit");
+			if ($hastrans) @pg_exec($this->_connectionID,'commit');
 			return $blob;
 		}
 		if (!$maxsize) $maxsize = $this->maxblobsize;
 		$realblob = @pg_lo_read($fd,$maxsize);
-		@pg_lo_close($fd);
-		if ($hastrans) @pg_exec($this->_connectionID,"commit");
+		@pg_loclose($fd);
+		if ($hastrans) @pg_exec($this->_connectionID,'commit');
 		return $realblob;
 	}
 
@@ -450,7 +450,7 @@ a different OID if a database must be reloaded. */
 	function UpdateBlob($table,$column,$val,$where,$blobtype='BLOB')
 	{
 		if ($blobtype == 'CLOB') {
-			return $this->Execute("UPDATE $table SET $column=" . $this->qstr($val) . " WHERE $where");
+			return $this->Execute('UPDATE $table SET $column=' . $this->qstr($val) . ' WHERE $where');
 		}
 		// do not use bind params which uses qstr(), as blobencode() already quotes data
 		return $this->Execute("UPDATE $table SET $column='".$this->BlobEncode($val)."'::bytea WHERE $where");
@@ -613,7 +613,7 @@ a different OID if a database must be reloaded. */
 		return '$'.$this->_pnum;
 	}
 
-	function MetaIndexes ($table, $primary = FALSE, $owner = false)
+	function MetaIndexes($table, $primary = FALSE, $owner = false)
 	{
 		global $ADODB_FETCH_MODE;
 
@@ -815,7 +815,7 @@ a different OID if a database must be reloaded. */
 					$sql .= $v.' $'.$i;
 					$i++;
 				}
-				$s = "PREPARE $plan ($params) AS ".substr($sql,0,strlen($sql)-2);
+				$s = 'PREPARE $plan ($params) AS '.substr($sql,0,strlen($sql)-2);
 				//adodb_pr($s);
 				$rez = pg_exec($this->_connectionID,$s);
 				//echo $this->ErrorMsg();
@@ -912,7 +912,7 @@ a different OID if a database must be reloaded. */
 
 class ADORecordSet_postgres64 extends ADORecordSet{
 	var $_blobArr;
-	var $databaseType = "postgres64";
+	var $databaseType = 'postgres64';
 	var $canSeek = true;
 
 	function __construct($queryID, $mode=false)

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -154,10 +154,10 @@ class ADODB_postgres64 extends ADOConnection{
 		return false;
 	}
 
-/* Warning from http://www.php.net/manual/function.pg-getlastoid.php:
-Using a OID as a unique identifier is not generally wise.
-Unless you are very careful, you might end up with a tuple having
-a different OID if a database must be reloaded. */
+	/* Warning from http://www.php.net/manual/function.pg-getlastoid.php:
+	Using a OID as a unique identifier is not generally wise.
+	Unless you are very careful, you might end up with a tuple having
+	a different OID if a database must be reloaded. */
 	function _insertid($table,$column)
 	{
 		if (!is_resource($this->_resultid) || get_resource_type($this->_resultid) !== 'pgsql result') return false;
@@ -166,8 +166,8 @@ a different OID if a database must be reloaded. */
 		return empty($table) || empty($column) ? $oid : $this->GetOne('SELECT $column FROM $table WHERE oid='.(int)$oid);
 	}
 
-// I get this error with PHP before 4.0.6 - jlim
-// Warning: This compilation does not support pg_cmdtuples() in adodb-postgres.inc.php on line 44
+	// I get this error with PHP before 4.0.6 - jlim
+	// Warning: This compilation does not support pg_cmdtuples() in adodb-postgres.inc.php on line 44
 	function _affectedrows()
 	{
 		if (!is_resource($this->_resultid) || get_resource_type($this->_resultid) !== 'pgsql result') return false;
@@ -175,12 +175,12 @@ a different OID if a database must be reloaded. */
 	}
 
 
-		// returns true/false
+	// returns true/false
 	function BeginTrans()
 	{
 		if ($this->transOff) return true;
 		$this->transCnt += 1;
-		return @pg_Exec($this->_connectionID, 'begin '.$this->_transmode);
+		return pg_query($this->_connectionID, 'begin '.$this->_transmode);
 	}
 
 	function RowLock($tables,$where,$col='1 as adodbignore')
@@ -196,7 +196,7 @@ a different OID if a database must be reloaded. */
 		if (!$ok) return $this->RollbackTrans();
 
 		$this->transCnt -= 1;
-		return @pg_Exec($this->_connectionID, 'commit');
+		return pg_query($this->_connectionID, 'commit');
 	}
 
 	// returns true/false
@@ -204,7 +204,7 @@ a different OID if a database must be reloaded. */
 	{
 		if ($this->transOff) return true;
 		$this->transCnt -= 1;
-		return @pg_Exec($this->_connectionID, 'rollback');
+		return pg_query($this->_connectionID, 'rollback');
 	}
 
 	function MetaTables($ttype=false,$showSchema=false,$mask=false)
@@ -413,16 +413,16 @@ a different OID if a database must be reloaded. */
 	{
 		if (!$this->GuessOID($blob)) return $blob;
 
-		if ($hastrans) @pg_query($this->_connectionID,'begin');
+		if ($hastrans) pg_query($this->_connectionID,'begin');
 		$fd = @pg_lo_open($this->_connectionID,$blob,'r');
 		if ($fd === false) {
-			if ($hastrans) @pg_query($this->_connectionID,'commit');
+			if ($hastrans) pg_query($this->_connectionID,'commit');
 			return $blob;
 		}
 		if (!$maxsize) $maxsize = $this->maxblobsize;
 		$realblob = @pg_lo_read($fd,$maxsize);
 		@pg_loclose($fd);
-		if ($hastrans) @pg_query($this->_connectionID,'commit');
+		if ($hastrans) pg_query($this->_connectionID,'commit');
 		return $realblob;
 	}
 


### PR DESCRIPTION
Minor fixes overall, mostly to better support HHVM v3.6. The biggest issue is pg_exec() is supposed to be for prepared statements, yet it was being called on mostly non-prepared statements. While this worked in stock PHP versions, it broke HHVM v3.6 and is "not correct(tm)" anyways, so its fixed now.