### PR TITLE
HHVM Fix for v3.6

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -3635,6 +3635,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		}
 
 		if ($rowNumber < 0) {
+			$this->EOF = true;
 			return false;
 		}
 

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -3634,6 +3634,10 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 			}
 		}
 
+		if ($rowNumber < 0) {
+			return false;
+		}
+
 		if ($this->canSeek) {
 			if ($this->_seek($rowNumber)) {
 				$this->_currentRow = $rowNumber;

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -154,10 +154,10 @@ class ADODB_postgres64 extends ADOConnection{
 		return false;
 	}
 
-/* Warning from http://www.php.net/manual/function.pg-getlastoid.php:
-Using a OID as a unique identifier is not generally wise.
-Unless you are very careful, you might end up with a tuple having
-a different OID if a database must be reloaded. */
+	/* Warning from http://www.php.net/manual/function.pg-getlastoid.php:
+	Using a OID as a unique identifier is not generally wise.
+	Unless you are very careful, you might end up with a tuple having
+	a different OID if a database must be reloaded. */
 	function _insertid($table,$column)
 	{
 		if (!is_resource($this->_resultid) || get_resource_type($this->_resultid) !== 'pgsql result') return false;
@@ -166,8 +166,8 @@ a different OID if a database must be reloaded. */
 		return empty($table) || empty($column) ? $oid : $this->GetOne("SELECT $column FROM $table WHERE oid=".(int)$oid);
 	}
 
-// I get this error with PHP before 4.0.6 - jlim
-// Warning: This compilation does not support pg_cmdtuples() in adodb-postgres.inc.php on line 44
+	// I get this error with PHP before 4.0.6 - jlim
+	// Warning: This compilation does not support pg_cmdtuples() in adodb-postgres.inc.php on line 44
 	function _affectedrows()
 	{
 		if (!is_resource($this->_resultid) || get_resource_type($this->_resultid) !== 'pgsql result') return false;
@@ -175,12 +175,12 @@ a different OID if a database must be reloaded. */
 	}
 
 
-		// returns true/false
+	// returns true/false
 	function BeginTrans()
 	{
 		if ($this->transOff) return true;
 		$this->transCnt += 1;
-		return @pg_Exec($this->_connectionID, "begin ".$this->_transmode);
+		return pg_query($this->_connectionID, 'begin '.$this->_transmode);
 	}
 
 	function RowLock($tables,$where,$col='1 as adodbignore')
@@ -196,7 +196,7 @@ a different OID if a database must be reloaded. */
 		if (!$ok) return $this->RollbackTrans();
 
 		$this->transCnt -= 1;
-		return @pg_Exec($this->_connectionID, "commit");
+		return pg_query($this->_connectionID, 'commit');
 	}
 
 	// returns true/false
@@ -204,7 +204,7 @@ a different OID if a database must be reloaded. */
 	{
 		if ($this->transOff) return true;
 		$this->transCnt -= 1;
-		return @pg_Exec($this->_connectionID, "rollback");
+		return pg_query($this->_connectionID, 'rollback');
 	}
 
 	function MetaTables($ttype=false,$showSchema=false,$mask=false)
@@ -413,16 +413,16 @@ a different OID if a database must be reloaded. */
 	{
 		if (!$this->GuessOID($blob)) return $blob;
 
-		if ($hastrans) @pg_exec($this->_connectionID,"begin");
-		$fd = @pg_lo_open($this->_connectionID,$blob,"r");
+		if ($hastrans) pg_query($this->_connectionID,'begin');
+		$fd = @pg_lo_open($this->_connectionID,$blob,'r');
 		if ($fd === false) {
-			if ($hastrans) @pg_exec($this->_connectionID,"commit");
+			if ($hastrans) pg_query($this->_connectionID,'commit');
 			return $blob;
 		}
 		if (!$maxsize) $maxsize = $this->maxblobsize;
 		$realblob = @pg_lo_read($fd,$maxsize);
-		@pg_lo_close($fd);
-		if ($hastrans) @pg_exec($this->_connectionID,"commit");
+		@pg_loclose($fd);
+		if ($hastrans) pg_query($this->_connectionID,'commit');
 		return $realblob;
 	}
 

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -413,7 +413,7 @@ class ADODB_postgres64 extends ADOConnection{
 	{
 		if (!$this->GuessOID($blob)) return $blob;
 
-		if ($hastrans) @pg_query($this->_connectionID,'begin');
+		if ($hastrans) pg_query($this->_connectionID,'begin');
 		$fd = @pg_lo_open($this->_connectionID,$blob,'r');
 		if ($fd === false) {
 			if ($hastrans) pg_query($this->_connectionID,'commit');

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -145,7 +145,7 @@ class ADODB_postgres64 extends ADOConnection{
 	// get the last id - never tested
 	function pg_insert_id($tablename,$fieldname)
 	{
-		$result=pg_exec($this->_connectionID, "SELECT last_value FROM ${tablename}_${fieldname}_seq");
+		$result=pg_query($this->_connectionID, 'SELECT last_value FROM '. $tablename .'_'. $fieldname .'_seq');
 		if ($result) {
 			$arr = @pg_fetch_row($result,0);
 			pg_free_result($result);
@@ -354,7 +354,7 @@ class ADODB_postgres64 extends ADOConnection{
 	*/
 	function UpdateBlobFile($table,$column,$path,$where,$blobtype='BLOB')
 	{
-		pg_exec ($this->_connectionID, "begin");
+		pg_query($this->_connectionID, 'begin');
 
 		$fd = fopen($path,'r');
 		$contents = fread($fd,filesize($path));
@@ -366,7 +366,7 @@ class ADODB_postgres64 extends ADOConnection{
 		pg_lo_close($handle);
 
 		// $oid = pg_lo_import ($path);
-		pg_exec($this->_connectionID, "commit");
+		pg_query($this->_connectionID, 'commit');
 		$rs = ADOConnection::UpdateBlob($table,$column,$oid,$where,$blobtype);
 		$rez = !empty($rs);
 		return $rez;
@@ -382,9 +382,9 @@ class ADODB_postgres64 extends ADOConnection{
 	*/
 	function BlobDelete( $blob )
 	{
-		pg_exec ($this->_connectionID, "begin");
+		pg_query($this->_connectionID, 'begin');
 		$result = @pg_lo_unlink($blob);
-		pg_exec ($this->_connectionID, "commit");
+		pg_query($this->_connectionID, 'commit');
 		return( $result );
 	}
 
@@ -413,7 +413,7 @@ class ADODB_postgres64 extends ADOConnection{
 	{
 		if (!$this->GuessOID($blob)) return $blob;
 
-		if ($hastrans) pg_query($this->_connectionID,'begin');
+		if ($hastrans) @pg_query($this->_connectionID,'begin');
 		$fd = @pg_lo_open($this->_connectionID,$blob,'r');
 		if ($fd === false) {
 			if ($hastrans) pg_query($this->_connectionID,'commit');
@@ -773,9 +773,6 @@ class ADODB_postgres64 extends ADOConnection{
 
 			with plan = 1.51861286163 secs
 			no plan =   1.26903700829 secs
-
-
-
 		*/
 			$plan = 'P'.md5($sql);
 
@@ -793,7 +790,7 @@ class ADODB_postgres64 extends ADOConnection{
 			else $exsql = "EXECUTE $plan";
 
 
-			$rez = @pg_exec($this->_connectionID,$exsql);
+			$rez = @pg_execute($this->_connectionID,$exsql);
 			if (!$rez) {
 			# Perhaps plan does not exist? Prepare/compile plan.
 				$params = '';
@@ -817,14 +814,14 @@ class ADODB_postgres64 extends ADOConnection{
 				}
 				$s = "PREPARE $plan ($params) AS ".substr($sql,0,strlen($sql)-2);
 				//adodb_pr($s);
-				$rez = pg_exec($this->_connectionID,$s);
+				$rez = pg_execute($this->_connectionID,$s);
 				//echo $this->ErrorMsg();
 			}
 			if ($rez)
-				$rez = pg_exec($this->_connectionID,$exsql);
+				$rez = pg_execute($this->_connectionID,$exsql);
 		} else {
 			//adodb_backtrace();
-			$rez = pg_exec($this->_connectionID,$sql);
+			$rez = pg_query($this->_connectionID,$sql);
 		}
 		// check if no data returned, then no need to create real recordset
 		if ($rez && pg_num_fields($rez) <= 0) {


### PR DESCRIPTION
This switches to using more standard PGSQL functions instead of legacy aliases to them, which helps fix issues with HHVM PGSQL extension. It also fixes a cases where warnings were being triggered and then having to be silenced.