### PR TITLE
[bugfix] ExtractSchema when prefix given and stripprefix

### DIFF
--- a/adodb-xmlschema03.inc.php
+++ b/adodb-xmlschema03.inc.php
@@ -2104,10 +2104,9 @@ class adoSchema {
 
 		$schema = '<?xml version="1.0"?>' . "\n"
 				. '<schema version="' . $this->schemaVersion . '">' . "\n";
-
-		if( is_array( $tables = $this->db->MetaTables( 'TABLES' , ($prefix) ? $prefix.'%' : '') ) ) {
+		if( is_array( $tables = $this->db->MetaTables( 'TABLES' ,false ,($prefix) ? str_replace('_','\_',$prefix).'%' : '') ) ) {
 			foreach( $tables as $table ) {
-				if ($stripprefix) $table = str_replace(str_replace('\\_', '_', $pfx ), '', $table);
+				$schema .= $indent.'<table name="'.htmlentities( $stripprefix ? str_replace($prefix, '', $table): $table ) . '">' . "\n";
 				$schema .= $indent . '<table name="' . htmlentities( $table ) . '">' . "\n";
 
 				// grab details from database


### PR DESCRIPTION
This patch addresses these issues when given param $prefix and $stripprefix.

  * missing param for the schema when calling MetaTables()
  * no table where returned if $stripprefix was true ($table name stripped, then later a sql select on that table name live, lol.
  * prefixes like 'mydbprefix_db1_' should not allow other tables starting 'mydbprefixXdb1_' or 'mydbprefix_db1X' to be matched as table for the result.

Tested only with mysqli.