### PR TITLE
Fix: mssqlnative fails on Insert_ID() if the insert statement contains a semicolon in a value string 

### DIFF
--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -563,7 +563,7 @@ class ADODB_mssqlnative extends ADOConnection {
 
 		$insert = false;
 		// handle native driver flaw for retrieving the last insert ID
-		if(preg_match('/^\W*(insert [^;]+);?$/i', $sql)) {
+		if(preg_match('/^\W*insert\s(?:(?:(?:\'\')*\'[^\']*\'(?:\'\')*)|[^;\'])*;?$/i', $sql)) {
 			$insert = true;
 			$sql .= '; '.$this->identitySQL; // select scope_identity()
 		}

--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -563,7 +563,7 @@ class ADODB_mssqlnative extends ADOConnection {
 
 		$insert = false;
 		// handle native driver flaw for retrieving the last insert ID
-		if(preg_match('/^\W*insert\s(?:(?:(?:\'\')*\'[^\']*\'(?:\'\')*)|[^;\'])*;?$/i', $sql)) {
+		if(preg_match('/^\W*insert\s(?:(?:(?:\'\')*\'[^\']+\'(?:\'\')*)|[^;\'])*;?$/i', $sql)) {
 			$insert = true;
 			$sql .= '; '.$this->identitySQL; // select scope_identity()
 		}


### PR DESCRIPTION
In mssql a tick mark (') in a value string is escaped via a second one. Therefore the number of tick marks before the semicolon must be odd (since the string starts with a tick mark). In my opinion semicolons should be allowed after an odd number of tick marks.
See also https://github.com/ADOdb/ADOdb/issues/96