### PR TITLE
mssqlnative: sqlsrv_configure(warnings_return_as_errors should be War…

### DIFF
--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -133,12 +133,12 @@ class ADODB_mssqlnative extends ADOConnection {
 			sqlsrv_set_error_handling( SQLSRV_ERRORS_LOG_ALL );
 			sqlsrv_log_set_severity( SQLSRV_LOG_SEVERITY_ALL );
 			sqlsrv_log_set_subsystems(SQLSRV_LOG_SYSTEM_ALL);
-			sqlsrv_configure('warnings_return_as_errors', 0);
+			sqlsrv_configure('WarningsReturnAsErrors', 0);
 		} else {
 			sqlsrv_set_error_handling(0);
 			sqlsrv_log_set_severity(0);
 			sqlsrv_log_set_subsystems(SQLSRV_LOG_SYSTEM_ALL);
-			sqlsrv_configure('warnings_return_as_errors', 0);
+			sqlsrv_configure('WarningsReturnAsErrors', 0);
 		}
 	}
 	function ServerVersion() {


### PR DESCRIPTION
In /Volumes/devmoodle/lib/adodb/drivers/adodb-mssqlnative.inc.php we find these three lines:

```
30:    sqlsrv_configure("WarningsReturnAsErrors", $constant);
142:  sqlsrv_configure('warnings_return_as_errors', 0);
147:  sqlsrv_configure('warnings_return_as_errors', 0);
```
The last two throw "error code = -14, sqlsrv_configure: message = An invalid parameter was passed to sqlsrv_configure".  The documentation confirms WarningsReturnAsErrors is correct,  warnings_return_as_errors is not.
See http://php.net/manual/en/function.sqlsrv-configure.php