### PR TITLE
Regarding "https://github.com/ADOdb/ADOdb/issues/126".

### DIFF
--- a/adodb-datadict.inc.php
+++ b/adodb-datadict.inc.php
@@ -197,22 +197,25 @@ class ADODB_DataDict {
 		return $this->connection->MetaTables();
 	}
 
+	//NOTE: THIS FUNCTION PROMISES TO QUOTE THE TABLE NAME, BUT THE PROMISE IS KEPT BY THE CORE ADODB
 	function MetaColumns($tab, $upper=true, $schema=false)
 	{
 		if (!$this->connection->IsConnected()) return array();
-		return $this->connection->MetaColumns($this->TableName($tab), $upper, $schema);
+		return $this->connection->MetaColumns($this->TableNameWithNoNameQuote($tab), $upper, $schema);
 	}
 
+	//NOTE: THIS FUNCTION PROMISES TO QUOTE THE TABLE NAME, BUT THE PROMISE IS KEPT BY THE CORE ADODB
 	function MetaPrimaryKeys($tab,$owner=false,$intkey=false)
 	{
 		if (!$this->connection->IsConnected()) return array();
-		return $this->connection->MetaPrimaryKeys($this->TableName($tab), $owner, $intkey);
+		return $this->connection->MetaPrimaryKeys($this->TableNameWithNoNameQuote($tab), $owner, $intkey);
 	}
 
+	//NOTE: THIS FUNCTION PROMISES TO QUOTE THE TABLE NAME, BUT THE PROMISE IS KEPT BY THE CORE ADODB
 	function MetaIndexes($table, $primary = false, $owner = false)
 	{
 		if (!$this->connection->IsConnected()) return array();
-		return $this->connection->MetaIndexes($this->TableName($table), $primary, $owner);
+		return $this->connection->MetaIndexes($this->TableNameWithNoNameQuote($table), $primary, $owner);
 	}
 
 	function MetaType($t,$len=-1,$fieldobj=false)
@@ -364,6 +367,28 @@ class ADODB_DataDict {
 			return $this->NameQuote($this->schema) .'.'. $this->NameQuote($name);
 		}
 		return $this->NameQuote($name);
+	}
+	
+	//PRIVATE	
+	function removeStandardAdodbDataDictNameQuotes($pName)
+	{
+		$vName = trim($pName);
+		$vMatches = NULL;
+
+		if(preg_match('/^`(.+)`$/', $vName, $vMatches))
+			{return $vMatches[1];}
+		return $vName;
+	}
+	
+	//PRIVATE
+	function TableNameWithNoNameQuote($pTableName)
+	{
+		if($this->schema)
+		{
+			return trim($this->schema).'.'.
+					$this->removeStandardAdodbDataDictNameQuotes($pTableName);
+		}
+		return $this->removeStandardAdodbDataDictNameQuotes($pTableName);
 	}
 
 	// Executes the sql array returned by GetTableSQL and GetIndexSQL

--- a/adodb-datadict.inc.php
+++ b/adodb-datadict.inc.php
@@ -198,25 +198,10 @@ class ADODB_DataDict {
 	}
 
 	//NOTE: THIS FUNCTION PROMISES TO QUOTE THE TABLE NAME, BUT THE PROMISE IS KEPT BY THE CORE ADODB
-	function MetaColumns($tab, $upper=null, $schema=false)
+	function MetaColumns($tab, $upper=true, $schema=false)
 	{
-		$vTableName = $this->removeStandardAdodbDataDictNameQuotes($tab);		
-
 		if (!$this->connection->IsConnected()) return array();
-		
-		if($upper === null)
-		{
-			$tIsToNormalize = $upper;
-
-			if(trim($tab) !== $vTableName)
-				{$tIsToNormalize = false;}
-			else
-				{$tIsToNormalize = true;}
-
-			return $this->connection->MetaColumns($vTableName, $tIsToNormalize, $schema);
-		}
-		else
-			{return $this->connection->MetaColumns($vTableName, $upper, $schema);}
+		return $this->connection->MetaColumns($this->TableNameWithNoNameQuote($tab), $upper, $schema);
 	}
 
 	//NOTE: THIS FUNCTION PROMISES TO QUOTE THE TABLE NAME, BUT THE PROMISE IS KEPT BY THE CORE ADODB

--- a/adodb-datadict.inc.php
+++ b/adodb-datadict.inc.php
@@ -198,10 +198,25 @@ class ADODB_DataDict {
 	}
 
 	//NOTE: THIS FUNCTION PROMISES TO QUOTE THE TABLE NAME, BUT THE PROMISE IS KEPT BY THE CORE ADODB
-	function MetaColumns($tab, $upper=true, $schema=false)
+	function MetaColumns($tab, $upper=null, $schema=false)
 	{
+		$vTableName = $this->removeStandardAdodbDataDictNameQuotes($tab);		
+
 		if (!$this->connection->IsConnected()) return array();
-		return $this->connection->MetaColumns($this->TableNameWithNoNameQuote($tab), $upper, $schema);
+		
+		if($upper === null)
+		{
+			$tIsToNormalize = $upper;
+
+			if(trim($tab) !== $vTableName)
+				{$tIsToNormalize = false;}
+			else
+				{$tIsToNormalize = true;}
+
+			return $this->connection->MetaColumns($vTableName, $tIsToNormalize, $schema);
+		}
+		else
+			{return $this->connection->MetaColumns($vTableName, $upper, $schema);}
 	}
 
 	//NOTE: THIS FUNCTION PROMISES TO QUOTE THE TABLE NAME, BUT THE PROMISE IS KEPT BY THE CORE ADODB

--- a/drivers/adodb-mysql.inc.php
+++ b/drivers/adodb-mysql.inc.php
@@ -180,7 +180,7 @@ class ADODB_mysql extends ADOConnection {
 		}
 
 		// get index details
-		$rs = $this->Execute(sprintf('SHOW INDEX FROM %s',$table));
+		$rs = $this->Execute(sprintf('SHOW INDEX FROM `%s`',$table));
 
 		// restore fetchmode
 		if (isset($savem)) {

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -338,7 +338,7 @@ class ADODB_mysqli extends ADOConnection {
 		}
 
 		// get index details
-		$rs = $this->Execute(sprintf('SHOW INDEXES FROM %s',$table));
+		$rs = $this->Execute(sprintf('SHOW INDEXES FROM `%s`',$table));
 
 		// restore fetchmode
 		if (isset($savem)) {


### PR DESCRIPTION
(Please note that the issue "https://github.com/ADOdb/ADOdb/issues/126" has been deemed a new feature request not a bug fix by the Maintainer of Adodb)

Going through code and documentation, it has become apparent that the library allows a person to include fields, table names and other identifiers in the AXMLS xml schema quoted with back-quotes (`). ADODB Data Dictionary is then responsible to replace back-quotes(`) with back-quotes(`), ("), (') or whatever quotation used by the underlying database. This can be seen in the code such as the function NameQuote in the file "adodb-datadict.inc.php", and in documentation, http://adodb.sourceforge.net/docs-datadict.htm. For example, one should be allowed to declare a table using:

     <table name="tableName">
or
     <table name="`tableName`">

where the second form would ensure the table name is properly quoted, which would avoid syntax errors if the table name is a reserved keyword, and in some databases would make the table name case sensitive.

It appears that ADODB Data Dictionary has been introduced later along with AXMLS, and AXMLS relies on this ADODB Data Dictionary. Unfortunately ADODB itself does not account for ADODB Data Dictionary's quotation feature, at least no where we have examined. A particular problem, for example, has been found with the function MetaColumns in the file "adodb-mysql.inc.php" where that function hard codes the quotation on the table in the sql statements it creates. This can been seen in the line:
var $metaColumnsSQL = "SHOW COLUMNS FROM `%s`"

That line was previously:
var $metaColumnsSQL = "SHOW COLUMNS FROM %s";

The change has been introduced with version 491, and although we do not know why, the change has been in line with all other drivers, apart from apparently "adodb-fbsql.inc.php". The function never expected the (`) quotation feature introduced by ADODB Data Dictionary. To further understand the problem, please examine and contrast the contradicting behavior of the function MetaColumns in the class ADODB_DataDict in the file "adodb-datadict.inc.php". This contradicting behavior is why we are convinced this is a bug.

When the XML with quoted table names is parsed and the MetaColumns function is called, the created query contains the ADODB Data Dictionary feature quotation, (`), processed and replaced with the correct identifier quotations per the ADODB Data Dictionary feature, but then quoted again by MetaColumns in "adodb-mysql.inc.php" (and other drivers), causing errors. To fix this properly, the ADODB library needs to be normalized with this feature in mind.

Although the ultimate aim is to normalize this feature in the entirety of ADODB, we are taking a simpler approach of fixing the calls made by ADODB Data Dictionary to ADODB. Please note the following:
- The approach assumes ADODB is completely unaware of the quotation feature. This has proven true everywhere in the code we looked.
- Un awareness of the feature is assumed when the code adds its own quotation, whether identifier quotation or string quotation. When no quotation is found, it could be awareness, a bug, or simply something specific to the particular database sql syntax.
- It appears the function ADOConnection::MetaColumns is unaware of the quotation feature, apart from possibly the driver "adodb-fbsql.inc.php". All drivers were examined to arrive at this conclusion.
- It appears the function ADOConnection::MetaIndexes is unaware of the quotation feature, apart from the drivers "adodb-mysqli.inc.php" and "adodb-mysql.inc.php", which we can conclude to be bugs, not awareness, due to our familiarity with Mysql. All drivers were examined to arrive at this conclusion.
- It appears the function ADOConnection::MetaPrimaryKeys is unaware of the quotation feature, apart from possibly the driver "adodb-odbtp.inc.php". All drivers were examined to arrive at this conclusion.