### PR TITLE
Sqlite driver array error.

### DIFF
--- a/drivers/adodb-sqlite.inc.php
+++ b/drivers/adodb-sqlite.inc.php
@@ -327,6 +327,9 @@ class ADODB_sqlite extends ADOConnection {
 			if ($primary && preg_match("/primary/i",$row[1]) == 0) {
 				continue;
 			}
+			//IGNORE AUTOMATICALLY CREATED INDICES
+			if (empty($row[1]))
+				{continue;}
 			if (!isset($indexes[$row[0]])) {
 				$indexes[$row[0]] = array(
 					'unique' => preg_match("/unique/i",$row[1]),

--- a/drivers/adodb-sqlite3.inc.php
+++ b/drivers/adodb-sqlite3.inc.php
@@ -310,6 +310,9 @@ class ADODB_sqlite3 extends ADOConnection {
 			if ($primary && preg_match("/primary/i",$row[1]) == 0) {
 				continue;
 			}
+			//IGNORE AUTOMATICALLY CREATED INDICES
+			if (empty($row[1]))
+				{continue;}
 			if (!isset($indexes[$row[0]])) {
 				$indexes[$row[0]] = array(
 					'unique' => preg_match("/unique/i",$row[1]),


### PR DESCRIPTION
Sqlite has automatically created indexes which can be safely assumed to be unaccounted for by calling code, such as AXMLS, as well as different to normal indices in terms of what may be done with them. Without this fix, a number of failures happen starting with the line

"$cols = explode(")",$cols[1]);"
later in the same function (MetaIndexes), as well as in AXMLS at least. The fix is a simple check to ensure the element '1' in the $row variable is not empty, which we observed happens with the automatically created indexes.