### PR TITLE
Remove PHP 4 Constructors

### DIFF
--- a/adodb-memcache.lib.inc.php
+++ b/adodb-memcache.lib.inc.php
@@ -48,7 +48,7 @@ $db->CacheExecute($sql);
 		var $_connected = false;
 		var $_memcache = false;
 
-		function ADODB_Cache_MemCache(&$obj)
+		function __construct(&$obj)
 		{
 			$this->hosts = $obj->memCacheHost;
 			$this->port = $obj->memCachePort;

--- a/adodb-pager.inc.php
+++ b/adodb-pager.inc.php
@@ -55,7 +55,7 @@ class ADODB_Pager {
 	//		if you have multiple on 1 page.
 	//		$id should be only be [a-z0-9]*
 	//
-	function ADODB_Pager(&$db,$sql,$id = 'adodb', $showPageLinks = false)
+	function __construct(&$db,$sql,$id = 'adodb', $showPageLinks = false)
 	{
 	global $PHP_SELF;
 

--- a/adodb-xmlschema.inc.php
+++ b/adodb-xmlschema.inc.php
@@ -118,7 +118,7 @@ class dbObject {
 	/**
 	* NOP
 	*/
-	function dbObject( &$parent, $attributes = NULL ) {
+	function __construct( &$parent, $attributes = NULL ) {
 		$this->parent = $parent;
 	}
 
@@ -248,7 +248,7 @@ class dbTable extends dbObject {
 	* @param string $prefix DB Object prefix
 	* @param array $attributes Array of table attributes.
 	*/
-	function dbTable( &$parent, $attributes = NULL ) {
+	function __construct( &$parent, $attributes = NULL ) {
 		$this->parent = $parent;
 		$this->name = $this->prefix($attributes['NAME']);
 	}
@@ -642,7 +642,7 @@ class dbIndex extends dbObject {
 	*
 	* @internal
 	*/
-	function dbIndex( &$parent, $attributes = NULL ) {
+	function __construct( &$parent, $attributes = NULL ) {
 		$this->parent = $parent;
 
 		$this->name = $this->prefix ($attributes['NAME']);
@@ -786,7 +786,7 @@ class dbData extends dbObject {
 	*
 	* @internal
 	*/
-	function dbData( &$parent, $attributes = NULL ) {
+	function __construct( &$parent, $attributes = NULL ) {
 		$this->parent = $parent;
 	}
 
@@ -985,7 +985,7 @@ class dbQuerySet extends dbObject {
 	* @param object $parent Parent object
 	* @param array $attributes Attributes
 	*/
-	function dbQuerySet( &$parent, $attributes = NULL ) {
+	function __construct( &$parent, $attributes = NULL ) {
 		$this->parent = $parent;
 
 		// Overrides the manual prefix key
@@ -1301,7 +1301,7 @@ class adoSchema {
 	*
 	* @param object $db ADOdb database connection object.
 	*/
-	function adoSchema( $db ) {
+	function __construct( $db ) {
 		// Initialize the environment
 		$this->mgq = get_magic_quotes_runtime();
 		ini_set("magic_quotes_runtime", 0);

--- a/adodb-xmlschema03.inc.php
+++ b/adodb-xmlschema03.inc.php
@@ -136,7 +136,7 @@ class dbObject {
 	/**
 	* NOP
 	*/
-	function dbObject( &$parent, $attributes = NULL ) {
+	function __construct( &$parent, $attributes = NULL ) {
 		$this->parent = $parent;
 	}
 
@@ -273,7 +273,7 @@ class dbTable extends dbObject {
 	* @param string $prefix DB Object prefix
 	* @param array $attributes Array of table attributes.
 	*/
-	function dbTable( &$parent, $attributes = NULL ) {
+	function __construct( &$parent, $attributes = NULL ) {
 		$this->parent = $parent;
 		$this->name = $this->prefix($attributes['NAME']);
 	}
@@ -683,7 +683,7 @@ class dbIndex extends dbObject {
 	*
 	* @internal
 	*/
-	function dbIndex( &$parent, $attributes = NULL ) {
+	function __construct( &$parent, $attributes = NULL ) {
 		$this->parent = $parent;
 
 		$this->name = $this->prefix ($attributes['NAME']);
@@ -828,7 +828,7 @@ class dbData extends dbObject {
 	*
 	* @internal
 	*/
-	function dbData( &$parent, $attributes = NULL ) {
+	function __construct( &$parent, $attributes = NULL ) {
 		$this->parent = $parent;
 	}
 
@@ -1084,7 +1084,7 @@ class dbQuerySet extends dbObject {
 	* @param object $parent Parent object
 	* @param array $attributes Attributes
 	*/
-	function dbQuerySet( &$parent, $attributes = NULL ) {
+	function __construct( &$parent, $attributes = NULL ) {
 		$this->parent = $parent;
 
 		// Overrides the manual prefix key
@@ -1405,7 +1405,7 @@ class adoSchema {
 	*
 	* @param object $db ADOdb database connection object.
 	*/
-	function adoSchema( $db ) {
+	function __construct( $db ) {
 		// Initialize the environment
 		$this->mgq = get_magic_quotes_runtime();
 		#set_magic_quotes_runtime(0);

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -304,7 +304,7 @@ if (!defined('_ADODB_LAYER')) {
 
 		var $createdir = true; // requires creation of temp dirs
 
-		function ADODB_Cache_File() {
+		function __construct() {
 			global $ADODB_INCLUDED_CSV;
 			if (empty($ADODB_INCLUDED_CSV)) {
 				include_once(ADODB_DIR.'/adodb-csvlib.inc.php');
@@ -3194,7 +3194,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	 * @param queryID	this is the queryID returned by ADOConnection->_query()
 	 *
 	 */
-	function ADORecordSet($queryID) {
+	function __construct($queryID) {
 		$this->_queryID = $queryID;
 	}
 
@@ -4293,12 +4293,12 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		/**
 		 * Constructor
 		 */
-		function ADORecordSet_array($fakeid=1) {
+		function __construct($fakeid=1) {
 			global $ADODB_FETCH_MODE,$ADODB_COMPAT_FETCH;
 
 			// fetch() on EOF does not delete $this->fields
 			$this->compat = !empty($ADODB_COMPAT_FETCH);
-			$this->ADORecordSet($fakeid); // fake queryID
+			parent::__construct($fakeid); // fake queryID
 			$this->fetchMode = $ADODB_FETCH_MODE;
 		}
 

--- a/drivers/adodb-access.inc.php
+++ b/drivers/adodb-access.inc.php
@@ -29,12 +29,12 @@ class  ADODB_access extends ADODB_odbc {
 	var $hasTransactions = false;
 	var $upperCase = 'ucase';
 
-	function ADODB_access()
+	function __construct()
 	{
 	global $ADODB_EXTENSION;
 
 		$ADODB_EXTENSION = false;
-		$this->ADODB_odbc();
+		parent::__construct();
 	}
 
 	function Time()
@@ -78,9 +78,9 @@ class  ADORecordSet_access extends ADORecordSet_odbc {
 
 	var $databaseType = "access";
 
-	function ADORecordSet_access($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_odbc($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }// class
 }

--- a/drivers/adodb-ado.inc.php
+++ b/drivers/adodb-ado.inc.php
@@ -37,7 +37,7 @@ class ADODB_ado extends ADOConnection {
 	var $poorAffectedRows = true;
 	var $charPage;
 
-	function ADODB_ado()
+	function __construct()
 	{
 		$this->_affectedRows = new VARIANT;
 	}
@@ -341,14 +341,14 @@ class ADORecordSet_ado extends ADORecordSet {
 	var $canSeek = true;
   	var $hideErrors = true;
 
-	function ADORecordSet_ado($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
 			$mode = $ADODB_FETCH_MODE;
 		}
 		$this->fetchMode = $mode;
-		return $this->ADORecordSet($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 
 

--- a/drivers/adodb-ado5.inc.php
+++ b/drivers/adodb-ado5.inc.php
@@ -37,7 +37,7 @@ class ADODB_ado extends ADOConnection {
 	var $poorAffectedRows = true;
 	var $charPage;
 
-	function ADODB_ado()
+	function __construct()
 	{
 		$this->_affectedRows = new VARIANT;
 	}
@@ -375,14 +375,14 @@ class ADORecordSet_ado extends ADORecordSet {
 	var $canSeek = true;
   	var $hideErrors = true;
 
-	function ADORecordSet_ado($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
 			$mode = $ADODB_FETCH_MODE;
 		}
 		$this->fetchMode = $mode;
-		return $this->ADORecordSet($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 
 

--- a/drivers/adodb-ado_access.inc.php
+++ b/drivers/adodb-ado_access.inc.php
@@ -28,11 +28,6 @@ class  ADODB_ado_access extends ADODB_ado {
 	var $sysTimeStamp = 'NOW';
 	var $upperCase = 'ucase';
 
-	function ADODB_ado_access()
-	{
-		$this->ADODB_ado();
-	}
-
 	/*function BeginTrans() { return false;}
 
 	function CommitTrans() { return false;}
@@ -46,8 +41,8 @@ class  ADORecordSet_ado_access extends ADORecordSet_ado {
 
 	var $databaseType = "ado_access";
 
-	function ADORecordSet_ado_access($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_ado($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-ado_mssql.inc.php
+++ b/drivers/adodb-ado_mssql.inc.php
@@ -39,11 +39,6 @@ class  ADODB_ado_mssql extends ADODB_ado {
 
 	//var $_inTransaction = 1; // always open recordsets, so no transaction problems.
 
-	function ADODB_ado_mssql()
-	{
-	        $this->ADODB_ado();
-	}
-
 	function _insertid()
 	{
 	        return $this->GetOne('select SCOPE_IDENTITY()');
@@ -146,8 +141,8 @@ class  ADODB_ado_mssql extends ADODB_ado {
 
 	var $databaseType = 'ado_mssql';
 
-	function ADORecordSet_ado_mssql($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-	        return $this->ADORecordSet_ado($id,$mode);
+	        return parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-ads.inc.php
+++ b/drivers/adodb-ads.inc.php
@@ -66,7 +66,7 @@ class ADODB_ads extends ADOConnection {
   var $uCaseTables = true; // for meta* functions, uppercase table names
 
 
-  function ADODB_ads()
+  function __construct()
   {
     $this->_haserrorfunctions = ADODB_PHPVER >= 0x4050;
     $this->_has_stupid_odbc_fetch_api_change = ADODB_PHPVER >= 0x4200;
@@ -654,7 +654,7 @@ class ADORecordSet_ads extends ADORecordSet {
   var $useFetchArray;
   var $_has_stupid_odbc_fetch_api_change;
 
-  function ADORecordSet_ads($id,$mode=false)
+  function __construct($id,$mode=false)
   {
     if ($mode === false) {
       global $ADODB_FETCH_MODE;
@@ -667,7 +667,7 @@ class ADORecordSet_ads extends ADORecordSet {
     // the following is required for mysql odbc driver in 4.3.1 -- why?
     $this->EOF = false;
     $this->_currentRow = -1;
-    //$this->ADORecordSet($id);
+    //parent::__construct($id);
   }
 
 

--- a/drivers/adodb-borland_ibase.inc.php
+++ b/drivers/adodb-borland_ibase.inc.php
@@ -20,12 +20,6 @@ include_once(ADODB_DIR."/drivers/adodb-ibase.inc.php");
 class ADODB_borland_ibase extends ADODB_ibase {
 	var $databaseType = "borland_ibase";
 
-
-	function ADODB_borland_ibase()
-	{
-		$this->ADODB_ibase();
-	}
-
 	function BeginTrans()
 	{
 		if ($this->transOff) return true;
@@ -84,8 +78,8 @@ class  ADORecordSet_borland_ibase extends ADORecordSet_ibase {
 
 	var $databaseType = "borland_ibase";
 
-	function ADORecordSet_borland_ibase($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		$this->ADORecordSet_ibase($id,$mode);
+		parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-csv.inc.php
+++ b/drivers/adodb-csv.inc.php
@@ -36,7 +36,7 @@ class ADODB_csv extends ADOConnection {
 	var $hasTransactions = false;
 	var $_errorNo = false;
 
-	function ADODB_csv()
+	function __construct()
 	{
 	}
 
@@ -191,9 +191,9 @@ class ADODB_csv extends ADOConnection {
 } // class
 
 class ADORecordset_csv extends ADORecordset {
-	function ADORecordset_csv($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		$this->ADORecordset($id,$mode);
+		parent::__construct($id,$mode);
 	}
 
 	function _close()

--- a/drivers/adodb-db2.inc.php
+++ b/drivers/adodb-db2.inc.php
@@ -61,7 +61,7 @@ class ADODB_db2 extends ADOConnection {
         return ADOConnection::GetOne('VALUES IDENTITY_VAL_LOCAL()');
     }
 
-	function ADODB_db2()
+	function __construct()
 	{
 		$this->_haserrorfunctions = ADODB_PHPVER >= 0x4050;
 	}
@@ -726,7 +726,7 @@ class ADORecordSet_db2 extends ADORecordSet {
 	var $dataProvider = "db2";
 	var $useFetchArray;
 
-	function ADORecordSet_db2($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;

--- a/drivers/adodb-db2oci.inc.php
+++ b/drivers/adodb-db2oci.inc.php
@@ -158,11 +158,6 @@ class ADODB_db2oci extends ADODB_db2 {
 	var $sysDate = 'trunc(sysdate)';
 	var $_bindInputArray = true;
 
-	function ADODB_db2oci()
-	{
-		parent::ADODB_db2();
-	}
-
 	function Param($name,$type='C')
 	{
 		return ':'.$name;
@@ -220,9 +215,9 @@ class  ADORecordSet_db2oci extends ADORecordSet_db2 {
 
 	var $databaseType = "db2oci";
 
-	function ADORecordSet_db2oci($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_db2($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }
 

--- a/drivers/adodb-db2ora.inc.php
+++ b/drivers/adodb-db2ora.inc.php
@@ -52,12 +52,6 @@ class ADODB_db2oci extends ADODB_db2 {
 	var $sysTimeStamp = 'sysdate';
 	var $sysDate = 'trunc(sysdate)';
 
-	function ADODB_db2oci()
-	{
-		$this->ADODB_db2();
-	}
-
-
 	function _Execute($sql, $inputarr)
 	{
 		if ($inputarr) list($sql,$inputarr) = _colonscope($sql, $inputarr);
@@ -70,9 +64,9 @@ class  ADORecordSet_db2oci extends ADORecordSet_odbc {
 
 	var $databaseType = "db2oci";
 
-	function ADORecordSet_db2oci($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_db2($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }
 

--- a/drivers/adodb-fbsql.inc.php
+++ b/drivers/adodb-fbsql.inc.php
@@ -23,7 +23,7 @@ class ADODB_fbsql extends ADOConnection {
 	var $fmtTimeStamp = "'Y-m-d H:i:s'";
 	var $hasLimit = false;
 
-	function ADODB_fbsql()
+	function __construct()
 	{
 	}
 
@@ -162,7 +162,7 @@ class ADORecordSet_fbsql extends ADORecordSet{
 	var $databaseType = "fbsql";
 	var $canSeek = true;
 
-	function ADORecordSet_fbsql($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 		if (!$mode) {
 			global $ADODB_FETCH_MODE;
@@ -175,7 +175,7 @@ class ADORecordSet_fbsql extends ADORecordSet{
 		default:
 		$this->fetchMode = FBSQL_BOTH; break;
 		}
-		return $this->ADORecordSet($queryID);
+		return parent::__construct($queryID);
 	}
 
 	function _initrs()

--- a/drivers/adodb-firebird.inc.php
+++ b/drivers/adodb-firebird.inc.php
@@ -21,11 +21,6 @@ class ADODB_firebird extends ADODB_ibase {
 
 	var $sysTimeStamp = "CURRENT_TIMESTAMP"; //"cast('NOW' as timestamp)";
 
-	function ADODB_firebird()
-	{
-		$this->ADODB_ibase();
-	}
-
 	function ServerInfo()
 	{
 		$arr['dialect'] = $this->dialect;
@@ -69,8 +64,8 @@ class  ADORecordSet_firebird extends ADORecordSet_ibase {
 
 	var $databaseType = "firebird";
 
-	function ADORecordSet_firebird($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		$this->ADORecordSet_ibase($id,$mode);
+		parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-ibase.inc.php
+++ b/drivers/adodb-ibase.inc.php
@@ -54,7 +54,7 @@ class ADODB_ibase extends ADOConnection {
 	var $blobEncodeType = 'C';
 	var $role = false;
 
-	function ADODB_ibase()
+	function __construct()
 	{
 		if (defined('IBASE_DEFAULT')) $this->ibasetrans = IBASE_DEFAULT;
 	}
@@ -759,12 +759,12 @@ class ADORecordset_ibase extends ADORecordSet
 	var $bind=false;
 	var $_cacheType;
 
-	function ADORecordset_ibase($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 	global $ADODB_FETCH_MODE;
 
 			$this->fetchMode = ($mode === false) ? $ADODB_FETCH_MODE : $mode;
-			$this->ADORecordSet($id);
+			parent::__construct($id);
 	}
 
 	/*		Returns: an object containing field information.

--- a/drivers/adodb-informix.inc.php
+++ b/drivers/adodb-informix.inc.php
@@ -32,8 +32,8 @@ class ADODB_informix extends ADODB_informix72 {
 class ADORecordset_informix extends ADORecordset_informix72 {
 	var $databaseType = "informix";
 
-	function ADORecordset_informix($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		$this->ADORecordset_informix72($id,$mode);
+		parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-informix72.inc.php
+++ b/drivers/adodb-informix72.inc.php
@@ -54,7 +54,7 @@ class ADODB_informix72 extends ADOConnection {
 	var $sysTimeStamp = 'CURRENT';
 	var $cursorType = IFX_SCROLL; // IFX_SCROLL or IFX_HOLD or 0
 
-	function ADODB_informix72()
+	function __construct()
 	{
 		// alternatively, use older method:
 		//putenv("DBDATE=Y4MD-");
@@ -391,14 +391,14 @@ class ADORecordset_informix72 extends ADORecordSet {
 	var $canSeek = true;
 	var $_fieldprops = false;
 
-	function ADORecordset_informix72($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
 			$mode = $ADODB_FETCH_MODE;
 		}
 		$this->fetchMode = $mode;
-		return $this->ADORecordSet($id);
+		return parent::__construct($id);
 	}
 
 

--- a/drivers/adodb-ldap.inc.php
+++ b/drivers/adodb-ldap.inc.php
@@ -43,7 +43,7 @@ class ADODB_ldap extends ADOConnection {
 	# error on binding, eg. "Binding: invalid credentials"
 	var $_bind_errmsg = "Binding: %s";
 
-	function ADODB_ldap()
+	function __construct()
 	{
 	}
 
@@ -292,7 +292,7 @@ class ADORecordSet_ldap extends ADORecordSet{
 	var $canSeek = false;
 	var $_entryID; /* keeps track of the entry resource identifier */
 
-	function ADORecordSet_ldap($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
@@ -313,7 +313,7 @@ class ADORecordSet_ldap extends ADORecordSet{
 			break;
 		}
 
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID);
 	}
 
 	function _initrs()

--- a/drivers/adodb-mssql.inc.php
+++ b/drivers/adodb-mssql.inc.php
@@ -105,7 +105,7 @@ class ADODB_mssql extends ADOConnection {
 	var $_bindInputArray = true;
 	var $forceNewConnect = false;
 
-	function ADODB_mssql()
+	function __construct()
 	{
 		$this->_has_mssql_init = (strnatcmp(PHP_VERSION,'4.1.0')>=0);
 	}
@@ -865,7 +865,7 @@ class ADORecordset_mssql extends ADORecordSet {
 	var $hasFetchAssoc; // see http://phplens.com/lens/lensforum/msgs.php?id=6083
 	// _mths works only in non-localised system
 
-	function ADORecordset_mssql($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		// freedts check...
 		$this->hasFetchAssoc = function_exists('mssql_fetch_assoc');
@@ -876,7 +876,7 @@ class ADORecordset_mssql extends ADORecordSet {
 
 		}
 		$this->fetchMode = $mode;
-		return $this->ADORecordSet($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 
 
@@ -1068,9 +1068,9 @@ class ADORecordset_mssql extends ADORecordSet {
 
 
 class ADORecordSet_array_mssql extends ADORecordSet_array {
-	function ADORecordSet_array_mssql($id=-1,$mode=false)
+	function __construct($id=-1,$mode=false)
 	{
-		$this->ADORecordSet_array($id,$mode);
+		parent::__construct($id,$mode);
 	}
 
 		// mssql uses a default date like Dec 30 2000 12:00AM

--- a/drivers/adodb-mssql_n.inc.php
+++ b/drivers/adodb-mssql_n.inc.php
@@ -163,8 +163,8 @@ class ADODB_mssql_n extends ADODB_mssql {
 
 class ADORecordset_mssql_n extends ADORecordset_mssql {
 	var $databaseType = "mssql_n";
-	function ADORecordset_mssql_n($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		$this->ADORecordset_mssql($id,$mode);
+		parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -126,7 +126,7 @@ class ADODB_mssqlnative extends ADOConnection {
 	var $sequences = false;
 	var $mssql_version = '';
 
-	function ADODB_mssqlnative()
+	function __construct()
 	{
 		if ($this->debug) {
 			ADOConnection::outp("<pre>");
@@ -838,7 +838,7 @@ class ADORecordset_mssqlnative extends ADORecordSet {
 	var $fieldOffset = 0;
 	// _mths works only in non-localised system
 
-	function ADORecordset_mssqlnative($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
@@ -846,7 +846,7 @@ class ADORecordset_mssqlnative extends ADORecordSet {
 
 		}
 		$this->fetchMode = $mode;
-		return $this->ADORecordSet($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 
 
@@ -1087,9 +1087,9 @@ class ADORecordset_mssqlnative extends ADORecordSet {
 
 
 class ADORecordSet_array_mssqlnative extends ADORecordSet_array {
-	function ADORecordSet_array_mssqlnative($id=-1,$mode=false)
+	function __construct($id=-1,$mode=false)
 	{
-		$this->ADORecordSet_array($id,$mode);
+		parent::__construct($id,$mode);
 	}
 
 		// mssql uses a default date like Dec 30 2000 12:00AM

--- a/drivers/adodb-mssqlpo.inc.php
+++ b/drivers/adodb-mssqlpo.inc.php
@@ -28,11 +28,6 @@ class ADODB_mssqlpo extends ADODB_mssql {
 	var $databaseType = "mssqlpo";
 	var $concat_operator = '||';
 
-	function ADODB_mssqlpo()
-	{
-		ADODB_mssql::ADODB_mssql();
-	}
-
 	function PrepareSP($sql)
 	{
 		if (!$this->_has_mssql_init) {
@@ -54,8 +49,8 @@ class ADODB_mssqlpo extends ADODB_mssql {
 
 class ADORecordset_mssqlpo extends ADORecordset_mssql {
 	var $databaseType = "mssqlpo";
-	function ADORecordset_mssqlpo($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		$this->ADORecordset_mssql($id,$mode);
+		parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-mysql.inc.php
+++ b/drivers/adodb-mysql.inc.php
@@ -45,7 +45,7 @@ class ADODB_mysql extends ADOConnection {
 	var $nameQuote = '`';		/// string to use to quote identifiers and names
 	var $compat323 = false; 		// true if compat with mysql 3.23
 
-	function ADODB_mysql()
+	function __construct()
 	{
 		if (defined('ADODB_EXTENSION')) $this->rsPrefix .= 'ext_';
 	}
@@ -708,7 +708,7 @@ class ADORecordSet_mysql extends ADORecordSet{
 	var $databaseType = "mysql";
 	var $canSeek = true;
 
-	function ADORecordSet_mysql($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
@@ -724,7 +724,7 @@ class ADORecordSet_mysql extends ADORecordSet{
 			$this->fetchMode = MYSQL_BOTH; break;
 		}
 		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID);
 	}
 
 	function _initrs()
@@ -870,23 +870,9 @@ class ADORecordSet_mysql extends ADORecordSet{
 }
 
 class ADORecordSet_ext_mysql extends ADORecordSet_mysql {
-	function ADORecordSet_ext_mysql($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
-		if ($mode === false) {
-			global $ADODB_FETCH_MODE;
-			$mode = $ADODB_FETCH_MODE;
-		}
-		switch ($mode)
-		{
-		case ADODB_FETCH_NUM: $this->fetchMode = MYSQL_NUM; break;
-		case ADODB_FETCH_ASSOC:$this->fetchMode = MYSQL_ASSOC; break;
-		case ADODB_FETCH_DEFAULT:
-		case ADODB_FETCH_BOTH:
-		default:
-		$this->fetchMode = MYSQL_BOTH; break;
-		}
-		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID,$mode);
 	}
 
 	function MoveNext()

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -57,7 +57,7 @@ class ADODB_mysqli extends ADOConnection {
 	var $arrayClass = 'ADORecordSet_array_mysqli';
 	var $multiQuery = false;
 
-	function ADODB_mysqli()
+	function __construct()
 	{
 		// if(!extension_loaded("mysqli"))
 		//trigger_error("You must have the mysqli extension installed.", E_USER_ERROR);
@@ -878,7 +878,7 @@ class ADORecordSet_mysqli extends ADORecordSet{
 	var $databaseType = "mysqli";
 	var $canSeek = true;
 
-	function ADORecordSet_mysqli($queryID, $mode = false)
+	function __construct($queryID, $mode = false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
@@ -899,7 +899,7 @@ class ADORecordSet_mysqli extends ADORecordSet{
 				break;
 		}
 		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID);
 	}
 
 	function _initrs()
@@ -1177,9 +1177,9 @@ class ADORecordSet_mysqli extends ADORecordSet{
 
 class ADORecordSet_array_mysqli extends ADORecordSet_array {
 
-	function ADORecordSet_array_mysqli($id=-1,$mode=false)
+	function __construct($id=-1,$mode=false)
 	{
-		$this->ADORecordSet_array($id,$mode);
+		parent::__construct($id,$mode);
 	}
 
 	function MetaType($t, $len = -1, $fieldobj = false)

--- a/drivers/adodb-mysqlpo.inc.php
+++ b/drivers/adodb-mysqlpo.inc.php
@@ -25,7 +25,7 @@ class ADODB_mysqlt extends ADODB_mysql {
 	var $hasTransactions = true;
 	var $autoRollback = true; // apparently mysql does not autorollback properly
 
-	function ADODB_mysqlt()
+	function __construct()
 	{
 	global $ADODB_EXTENSION; if ($ADODB_EXTENSION) $this->rsPrefix .= 'ext_';
 	}
@@ -72,7 +72,7 @@ class ADODB_mysqlt extends ADODB_mysql {
 class ADORecordSet_mysqlt extends ADORecordSet_mysql{
 	var $databaseType = "mysqlt";
 
-	function ADORecordSet_mysqlt($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
@@ -90,7 +90,7 @@ class ADORecordSet_mysqlt extends ADORecordSet_mysql{
 		}
 
 		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID);
 	}
 
 	function MoveNext()
@@ -109,24 +109,9 @@ class ADORecordSet_mysqlt extends ADORecordSet_mysql{
 
 class ADORecordSet_ext_mysqlt extends ADORecordSet_mysqlt {
 
-	function ADORecordSet_ext_mysqlt($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
-		if ($mode === false) {
-			global $ADODB_FETCH_MODE;
-			$mode = $ADODB_FETCH_MODE;
-		}
-		switch ($mode)
-		{
-		case ADODB_FETCH_NUM: $this->fetchMode = MYSQL_NUM; break;
-		case ADODB_FETCH_ASSOC:$this->fetchMode = MYSQL_ASSOC; break;
-
-		case ADODB_FETCH_DEFAULT:
-		case ADODB_FETCH_BOTH:
-		default:
-			$this->fetchMode = MYSQL_BOTH; break;
-		}
-		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID,$mode);
 	}
 
 	function MoveNext()

--- a/drivers/adodb-mysqlt.inc.php
+++ b/drivers/adodb-mysqlt.inc.php
@@ -25,7 +25,7 @@ class ADODB_mysqlt extends ADODB_mysql {
 	var $hasTransactions = true;
 	var $autoRollback = true; // apparently mysql does not autorollback properly
 
-	function ADODB_mysqlt()
+	function __construct()
 	{
 	global $ADODB_EXTENSION; if ($ADODB_EXTENSION) $this->rsPrefix .= 'ext_';
 	}
@@ -89,7 +89,7 @@ class ADODB_mysqlt extends ADODB_mysql {
 class ADORecordSet_mysqlt extends ADORecordSet_mysql{
 	var $databaseType = "mysqlt";
 
-	function ADORecordSet_mysqlt($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
@@ -107,7 +107,7 @@ class ADORecordSet_mysqlt extends ADORecordSet_mysql{
 		}
 
 		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID);
 	}
 
 	function MoveNext()
@@ -128,22 +128,7 @@ class ADORecordSet_ext_mysqlt extends ADORecordSet_mysqlt {
 
 	function ADORecordSet_ext_mysqlt($queryID,$mode=false)
 	{
-		if ($mode === false) {
-			global $ADODB_FETCH_MODE;
-			$mode = $ADODB_FETCH_MODE;
-		}
-		switch ($mode)
-		{
-		case ADODB_FETCH_NUM: $this->fetchMode = MYSQL_NUM; break;
-		case ADODB_FETCH_ASSOC:$this->fetchMode = MYSQL_ASSOC; break;
-
-		case ADODB_FETCH_DEFAULT:
-		case ADODB_FETCH_BOTH:
-		default:
-			$this->fetchMode = MYSQL_BOTH; break;
-		}
-		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID,$mode);
 	}
 
 	function MoveNext()

--- a/drivers/adodb-netezza.inc.php
+++ b/drivers/adodb-netezza.inc.php
@@ -48,7 +48,7 @@ class ADODB_netezza extends ADODB_postgres64 {
 							// http://bugs.php.net/bug.php?id=25404
 
 
-	function ADODB_netezza()
+	function __construct()
 	{
 
 	}
@@ -139,23 +139,9 @@ class ADORecordSet_netezza extends ADORecordSet_postgres64
 	var $databaseType = "netezza";
 	var $canSeek = true;
 
-	function ADORecordSet_netezza($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
-		if ($mode === false) {
-			global $ADODB_FETCH_MODE;
-			$mode = $ADODB_FETCH_MODE;
-		}
-		switch ($mode)
-		{
-		case ADODB_FETCH_NUM: $this->fetchMode = PGSQL_NUM; break;
-		case ADODB_FETCH_ASSOC:$this->fetchMode = PGSQL_ASSOC; break;
-
-		case ADODB_FETCH_DEFAULT:
-		case ADODB_FETCH_BOTH:
-		default: $this->fetchMode = PGSQL_BOTH; break;
-		}
-		$this->adodbFetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID,$mode);
 	}
 
 	// _initrs modified to disable blob handling

--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -101,7 +101,7 @@ END;
 
 	// var $ansiOuter = true; // if oracle9
 
-	function ADODB_oci8()
+	function __construct()
 	{
 		$this->_hasOciFetchStatement = ADODB_PHPVER >= 0x4200;
 		if (defined('ADODB_EXTENSION')) {
@@ -1534,7 +1534,7 @@ class ADORecordset_oci8 extends ADORecordSet {
 	var $bind=false;
 	var $_fieldobjs;
 
-	function ADORecordset_oci8($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
@@ -1800,7 +1800,7 @@ class ADORecordset_oci8 extends ADORecordSet {
 }
 
 class ADORecordSet_ext_oci8 extends ADORecordSet_oci8 {
-	function ADORecordSet_ext_oci8($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 		parent::__construct($queryID, $mode);
 	}

--- a/drivers/adodb-oci805.inc.php
+++ b/drivers/adodb-oci805.inc.php
@@ -21,11 +21,6 @@ class ADODB_oci805 extends ADODB_oci8 {
 	var $databaseType = "oci805";
 	var $connectSID = true;
 
-	function ADODB_oci805()
-	{
-		$this->ADODB_oci8();
-	}
-
 	function SelectLimit($sql,$nrows=-1,$offset=-1, $inputarr=false,$secs2cache=0)
 	{
 		// seems that oracle only supports 1 hint comment in 8i
@@ -51,8 +46,8 @@ class ADODB_oci805 extends ADODB_oci8 {
 
 class ADORecordset_oci805 extends ADORecordset_oci8 {
 	var $databaseType = "oci805";
-	function ADORecordset_oci805($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		$this->ADORecordset_oci8($id,$mode);
+		parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-oci8po.inc.php
+++ b/drivers/adodb-oci8po.inc.php
@@ -28,7 +28,7 @@ class ADODB_oci8po extends ADODB_oci8 {
 	var $metaColumnsSQL = "select lower(cname),coltype,width, SCALE, PRECISION, NULLS, DEFAULTVAL from col where tname='%s' order by colno"; //changed by smondino@users.sourceforge. net
 	var $metaTablesSQL = "select lower(table_name),table_type from cat where table_type in ('TABLE','VIEW')";
 
-	function ADODB_oci8po()
+	function __construct()
 	{
 		$this->_hasOCIFetchStatement = ADODB_PHPVER >= 0x4200;
 		# oci8po does not support adodb extension: adodb_movenext()
@@ -94,9 +94,9 @@ class ADORecordset_oci8po extends ADORecordset_oci8 {
 
 	var $databaseType = 'oci8po';
 
-	function ADORecordset_oci8po($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
-		$this->ADORecordset_oci8($queryID,$mode);
+		parent::__construct($queryID,$mode);
 	}
 
 	function Fields($colname)

--- a/drivers/adodb-oci8quercus.inc.php
+++ b/drivers/adodb-oci8quercus.inc.php
@@ -26,7 +26,7 @@ class ADODB_oci8quercus extends ADODB_oci8 {
 	var $databaseType = 'oci8quercus';
 	var $dataProvider = 'oci8';
 
-	function ADODB_oci8quercus()
+	function __construct()
 	{
 	}
 
@@ -40,9 +40,9 @@ class ADORecordset_oci8quercus extends ADORecordset_oci8 {
 
 	var $databaseType = 'oci8quercus';
 
-	function ADORecordset_oci8quercus($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
-		$this->ADORecordset_oci8($queryID,$mode);
+		parent::__construct($queryID,$mode);
 	}
 
 	function _FetchField($fieldOffset = -1)

--- a/drivers/adodb-odbc.inc.php
+++ b/drivers/adodb-odbc.inc.php
@@ -39,7 +39,7 @@ class ADODB_odbc extends ADOConnection {
 	var $_lastAffectedRows = 0;
 	var $uCaseTables = true; // for meta* functions, uppercase table names
 
-	function ADODB_odbc()
+	function __construct()
 	{
 		$this->_haserrorfunctions = ADODB_PHPVER >= 0x4050;
 		$this->_has_stupid_odbc_fetch_api_change = ADODB_PHPVER >= 0x4200;
@@ -606,7 +606,7 @@ class ADORecordSet_odbc extends ADORecordSet {
 	var $useFetchArray;
 	var $_has_stupid_odbc_fetch_api_change;
 
-	function ADORecordSet_odbc($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
@@ -619,7 +619,7 @@ class ADORecordSet_odbc extends ADORecordSet {
 		// the following is required for mysql odbc driver in 4.3.1 -- why?
 		$this->EOF = false;
 		$this->_currentRow = -1;
-		//$this->ADORecordSet($id);
+		//parent::__construct($id);
 	}
 
 

--- a/drivers/adodb-odbc_db2.inc.php
+++ b/drivers/adodb-odbc_db2.inc.php
@@ -110,10 +110,10 @@ class ADODB_ODBC_DB2 extends ADODB_odbc {
 	 var $hasInsertID = true;
 	var $rsPrefix = 'ADORecordset_odbc_';
 
-	function ADODB_DB2()
+	function __construct()
 	{
 		if (strncmp(PHP_OS,'WIN',3) === 0) $this->curmode = SQL_CUR_USE_ODBC;
-		$this->ADODB_odbc();
+		parent::__construct();
 	}
 
 	function IfNull( $field, $ifNull )
@@ -304,9 +304,9 @@ class  ADORecordSet_odbc_db2 extends ADORecordSet_odbc {
 
 	var $databaseType = "db2";
 
-	function ADORecordSet_db2($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		$this->ADORecordSet_odbc($id,$mode);
+		parent::__construct($id,$mode);
 	}
 
 	function MetaType($t,$len=-1,$fieldobj=false)

--- a/drivers/adodb-odbc_mssql.inc.php
+++ b/drivers/adodb-odbc_mssql.inc.php
@@ -45,9 +45,9 @@ class  ADODB_odbc_mssql extends ADODB_odbc {
 	var $connectStmt = 'SET CONCAT_NULL_YIELDS_NULL OFF'; # When SET CONCAT_NULL_YIELDS_NULL is ON,
 														  # concatenating a null value with a string yields a NULL result
 
-	function ADODB_odbc_mssql()
+	function __construct()
 	{
-		$this->ADODB_odbc();
+		parent::__construct();
 		//$this->curmode = SQL_CUR_USE_ODBC;
 	}
 
@@ -354,8 +354,8 @@ class  ADORecordSet_odbc_mssql extends ADORecordSet_odbc {
 
 	var $databaseType = 'odbc_mssql';
 
-	function ADORecordSet_odbc_mssql($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_odbc($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-odbc_oracle.inc.php
+++ b/drivers/adodb-odbc_oracle.inc.php
@@ -31,11 +31,6 @@ class  ADODB_odbc_oracle extends ADODB_odbc {
 
 	//var $_bindInputArray = false;
 
-	function ADODB_odbc_oracle()
-	{
-		$this->ADODB_odbc();
-	}
-
 	function MetaTables()
 	{
 		$false = false;
@@ -107,8 +102,8 @@ class  ADORecordSet_odbc_oracle extends ADORecordSet_odbc {
 
 	var $databaseType = 'odbc_oracle';
 
-	function ADORecordSet_odbc_oracle($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_odbc($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-odbtp.inc.php
+++ b/drivers/adodb-odbtp.inc.php
@@ -33,7 +33,7 @@ class ADODB_odbtp extends ADOConnection{
 	var $_canPrepareSP = false;
 	var $_dontPoolDBC = true;
 
-	function ADODB_odbtp()
+	function __construct()
 	{
 	}
 
@@ -668,14 +668,14 @@ class ADORecordSet_odbtp extends ADORecordSet {
 	var $databaseType = 'odbtp';
 	var $canSeek = true;
 
-	function ADORecordSet_odbtp($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
 			$mode = $ADODB_FETCH_MODE;
 		}
 		$this->fetchMode = $mode;
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID);
 	}
 
 	function _initrs()
@@ -791,9 +791,9 @@ class ADORecordSet_odbtp_mssql extends ADORecordSet_odbtp {
 
 	var $databaseType = 'odbtp_mssql';
 
-	function ADORecordSet_odbtp_mssql($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_odbtp($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }
 
@@ -801,9 +801,9 @@ class ADORecordSet_odbtp_access extends ADORecordSet_odbtp {
 
 	var $databaseType = 'odbtp_access';
 
-	function ADORecordSet_odbtp_access($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_odbtp($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }
 
@@ -811,9 +811,9 @@ class ADORecordSet_odbtp_vfp extends ADORecordSet_odbtp {
 
 	var $databaseType = 'odbtp_vfp';
 
-	function ADORecordSet_odbtp_vfp($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_odbtp($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }
 
@@ -821,9 +821,9 @@ class ADORecordSet_odbtp_oci8 extends ADORecordSet_odbtp {
 
 	var $databaseType = 'odbtp_oci8';
 
-	function ADORecordSet_odbtp_oci8($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_odbtp($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }
 
@@ -831,8 +831,8 @@ class ADORecordSet_odbtp_sybase extends ADORecordSet_odbtp {
 
 	var $databaseType = 'odbtp_sybase';
 
-	function ADORecordSet_odbtp_sybase($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_odbtp($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 }

--- a/drivers/adodb-odbtp_unicode.inc.php
+++ b/drivers/adodb-odbtp_unicode.inc.php
@@ -30,9 +30,4 @@ if (!defined('_ADODB_ODBTP_LAYER')) {
 class ADODB_odbtp_unicode extends ADODB_odbtp {
 	var $databaseType = 'odbtp';
 	var $_useUnicodeSQL = true;
-
-	function ADODB_odbtp_unicode()
-	{
-		$this->ADODB_odbtp();
-	}
 }

--- a/drivers/adodb-oracle.inc.php
+++ b/drivers/adodb-oracle.inc.php
@@ -27,7 +27,7 @@ class ADODB_oracle extends ADOConnection {
 	var $sysTimeStamp = 'SYSDATE';
 	var $connectSID = true;
 
-	function ADODB_oracle()
+	function __construct()
 	{
 	}
 
@@ -219,7 +219,7 @@ class ADORecordset_oracle extends ADORecordSet {
 	var $databaseType = "oracle";
 	var $bind = false;
 
-	function ADORecordset_oracle($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 
 		if ($mode === false) {

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -85,7 +85,7 @@ class ADODB_pdo extends ADOConnection {
 	var $stmt = false;
 	var $_driver;
 
-	function ADODB_pdo()
+	function __construct()
 	{
 	}
 
@@ -548,7 +548,7 @@ class ADOPDOStatement {
 	var $_stmt;
 	var $_connectionID;
 
-	function ADOPDOStatement($stmt,$connection)
+	function __construct($stmt,$connection)
 	{
 		$this->_stmt = $stmt;
 		$this->_connectionID = $connection;
@@ -625,7 +625,7 @@ class ADORecordSet_pdo extends ADORecordSet {
 	var $databaseType = "pdo";
 	var $dataProvider = "pdo";
 
-	function ADORecordSet_pdo($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
@@ -642,7 +642,7 @@ class ADORecordSet_pdo extends ADORecordSet {
 		$this->fetchMode = $mode;
 
 		$this->_queryID = $id;
-		$this->ADORecordSet($id);
+		parent::__construct($id);
 	}
 
 

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -932,7 +932,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 		$this->adodbFetchMode = $mode;
 
 		// Parent's constructor
-		$this->ADORecordSet($queryID);
+		parent::__construct($queryID);
 	}
 
 	function GetRowAssoc($upper = ADODB_ASSOC_CASE)

--- a/drivers/adodb-proxy.inc.php
+++ b/drivers/adodb-proxy.inc.php
@@ -23,9 +23,9 @@ if (! defined("_ADODB_PROXY_LAYER")) {
 	class ADORecordset_proxy extends ADORecordset_csv {
 	var $databaseType = "proxy";
 
-		function ADORecordset_proxy($id,$mode=false)
+		function __construct($id,$mode=false)
 		{
-			$this->ADORecordset($id,$mode);
+			parent::__construct($id,$mode);
 		}
 	};
 } // define

--- a/drivers/adodb-sapdb.inc.php
+++ b/drivers/adodb-sapdb.inc.php
@@ -31,10 +31,10 @@ class ADODB_SAPDB extends ADODB_odbc {
 	var $hasInsertId = true;
 	var $_bindInputArray = true;
 
-	function ADODB_SAPDB()
+	function __construct()
 	{
 		//if (strncmp(PHP_OS,'WIN',3) === 0) $this->curmode = SQL_CUR_USE_ODBC;
-		$this->ADODB_odbc();
+		parent::__construct();
 	}
 
 	function ServerInfo()
@@ -174,9 +174,9 @@ class  ADORecordSet_sapdb extends ADORecordSet_odbc {
 
 	var $databaseType = "sapdb";
 
-	function ADORecordSet_sapdb($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		$this->ADORecordSet_odbc($id,$mode);
+		parent::__construct($id,$mode);
 	}
 }
 

--- a/drivers/adodb-sqlanywhere.inc.php
+++ b/drivers/adodb-sqlanywhere.inc.php
@@ -56,11 +56,6 @@ if (!defined('ADODB_SYBASE_SQLANYWHERE')){
   	var $databaseType = "sqlanywhere";
 	var $hasInsertID = true;
 
-	function ADODB_sqlanywhere()
-	{
-		$this->ADODB_odbc();
-	}
-
 	 function _insertid() {
   	   return $this->GetOne('select @@identity');
 	 }
@@ -156,9 +151,9 @@ if (!defined('ADODB_SYBASE_SQLANYWHERE')){
 
   var $databaseType = "sqlanywhere";
 
- function ADORecordSet_sqlanywhere($id,$mode=false)
+ function __construct($id,$mode=false)
  {
-  $this->ADORecordSet_odbc($id,$mode);
+  parent::__construct($id,$mode);
  }
 
 

--- a/drivers/adodb-sqlite.inc.php
+++ b/drivers/adodb-sqlite.inc.php
@@ -31,7 +31,7 @@ class ADODB_sqlite extends ADOConnection {
 	var $sysTimeStamp = "adodb_date('Y-m-d H:i:s')";
 	var $fmtTimeStamp = "'Y-m-d H:i:s'";
 
-	function ADODB_sqlite()
+	function __construct()
 	{
 	}
 
@@ -362,7 +362,7 @@ class ADORecordset_sqlite extends ADORecordSet {
 	var $databaseType = "sqlite";
 	var $bind = false;
 
-	function ADORecordset_sqlite($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 
 		if ($mode === false) {

--- a/drivers/adodb-sqlite3.inc.php
+++ b/drivers/adodb-sqlite3.inc.php
@@ -31,7 +31,7 @@ class ADODB_sqlite3 extends ADOConnection {
 	var $sysTimeStamp = "adodb_date('Y-m-d H:i:s')";
 	var $fmtTimeStamp = "'Y-m-d H:i:s'";
 
-	function ADODB_sqlite3()
+	function __construct()
 	{
 	}
 
@@ -345,7 +345,7 @@ class ADORecordset_sqlite3 extends ADORecordSet {
 	var $databaseType = "sqlite3";
 	var $bind = false;
 
-	function ADORecordset_sqlite3($queryID,$mode=false)
+	function __construct($queryID,$mode=false)
 	{
 
 		if ($mode === false) {

--- a/drivers/adodb-sqlitepo.inc.php
+++ b/drivers/adodb-sqlitepo.inc.php
@@ -23,11 +23,6 @@ include_once(ADODB_DIR.'/drivers/adodb-sqlite.inc.php');
 
 class ADODB_sqlitepo extends ADODB_sqlite {
    var $databaseType = 'sqlitepo';
-
-   function ADODB_sqlitepo()
-   {
-      $this->ADODB_sqlite();
-   }
 }
 
 /*--------------------------------------------------------------------------------------
@@ -38,9 +33,9 @@ class ADORecordset_sqlitepo extends ADORecordset_sqlite {
 
    var $databaseType = 'sqlitepo';
 
-   function ADORecordset_sqlitepo($queryID,$mode=false)
+   function __construct($queryID,$mode=false)
    {
-      $this->ADORecordset_sqlite($queryID,$mode);
+      parent::__construct($queryID,$mode);
    }
 
    // Modified to strip table names from returned fields

--- a/drivers/adodb-sybase.inc.php
+++ b/drivers/adodb-sybase.inc.php
@@ -42,7 +42,7 @@ class ADODB_sybase extends ADOConnection {
 
 	var $port;
 
-	function ADODB_sybase()
+	function __construct()
 	{
 	}
 
@@ -308,7 +308,7 @@ class ADORecordset_sybase extends ADORecordSet {
 	// _mths works only in non-localised system
 	var  $_mths = array('JAN'=>1,'FEB'=>2,'MAR'=>3,'APR'=>4,'MAY'=>5,'JUN'=>6,'JUL'=>7,'AUG'=>8,'SEP'=>9,'OCT'=>10,'NOV'=>11,'DEC'=>12);
 
-	function ADORecordset_sybase($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
 		if ($mode === false) {
 			global $ADODB_FETCH_MODE;
@@ -316,7 +316,7 @@ class ADORecordset_sybase extends ADORecordSet {
 		}
 		if (!$mode) $this->fetchMode = ADODB_FETCH_ASSOC;
 		else $this->fetchMode = $mode;
-		$this->ADORecordSet($id,$mode);
+		parent::__construct($id,$mode);
 	}
 
 	/*	Returns: an object containing field information.
@@ -389,9 +389,9 @@ class ADORecordset_sybase extends ADORecordSet {
 }
 
 class ADORecordSet_array_sybase extends ADORecordSet_array {
-	function ADORecordSet_array_sybase($id=-1)
+	function __construct($id=-1)
 	{
-		$this->ADORecordSet_array($id);
+		parent::__construct($id);
 	}
 
 		// sybase/mssql uses a default date like Dec 30 2000 12:00AM

--- a/drivers/adodb-sybase_ase.inc.php
+++ b/drivers/adodb-sybase_ase.inc.php
@@ -20,7 +20,7 @@ class ADODB_sybase_ase extends ADODB_sybase {
 	 var $metaColumnsSQL = "SELECT syscolumns.name AS field_name, systypes.name AS type, systypes.length AS width FROM sysobjects, syscolumns, systypes WHERE sysobjects.name='%s' AND syscolumns.id = sysobjects.id AND systypes.type=syscolumns.type";
 	 var $metaDatabasesSQL ="SELECT a.name FROM master.dbo.sysdatabases a, master.dbo.syslogins b WHERE a.suid = b.suid and a.name like '%' and a.name != 'tempdb' and a.status3 != 256  order by 1";
 
-	function ADODB_sybase_ase()
+	function __construct()
 	{
 	}
 
@@ -110,9 +110,9 @@ class ADODB_sybase_ase extends ADODB_sybase {
 
 class adorecordset_sybase_ase extends ADORecordset_sybase {
 var $databaseType = "sybase_ase";
-function ADORecordset_sybase_ase($id,$mode=false)
+function __construct($id,$mode=false)
 	{
-		$this->ADORecordSet_sybase($id,$mode);
+		parent::__construct($id,$mode);
 	}
 
 }

--- a/drivers/adodb-text.inc.php
+++ b/drivers/adodb-text.inc.php
@@ -88,7 +88,7 @@ class ADODB_text extends ADOConnection {
 	var $_reznames;
 	var $_reztypes;
 
-	function ADODB_text()
+	function __construct()
 	{
 	}
 
@@ -374,9 +374,9 @@ class ADORecordSet_text extends ADORecordSet_array
 
 	var $databaseType = "text";
 
-	function ADORecordSet_text(&$conn,$mode=false)
+	function __construct(&$conn,$mode=false)
 	{
-		$this->ADORecordSet_array();
+		parent::__construct();
 		$this->InitArray($conn->_rezarray,$conn->_reztypes,$conn->_reznames);
 		$conn->_rezarray = false;
 	}

--- a/drivers/adodb-vfp.inc.php
+++ b/drivers/adodb-vfp.inc.php
@@ -34,11 +34,6 @@ class ADODB_vfp extends ADODB_odbc {
 	var $hasTransactions = false;
 	var $curmode = false ; // See sqlext.h, SQL_CUR_DEFAULT == SQL_CUR_USE_DRIVER == 2L
 
-	function ADODB_vfp()
-	{
-		$this->ADODB_odbc();
-	}
-
 	function Time()
 	{
 		return time();
@@ -72,9 +67,9 @@ class  ADORecordSet_vfp extends ADORecordSet_odbc {
 	var $databaseType = "vfp";
 
 
-	function ADORecordSet_vfp($id,$mode=false)
+	function __construct($id,$mode=false)
 	{
-		return $this->ADORecordSet_odbc($id,$mode);
+		return parent::__construct($id,$mode);
 	}
 
 	function MetaType($t,$len=-1)

--- a/pear/Auth/Container/ADOdb.php
+++ b/pear/Auth/Container/ADOdb.php
@@ -61,7 +61,7 @@ class Auth_Container_ADOdb extends Auth_Container
      * @param  string Connection data or DB object
      * @return object Returns an error object if something went wrong
      */
-    function Auth_Container_ADOdb($dsn)
+    function __construct($dsn)
     {
         $this->_setDefaults();
 

--- a/perf/perf-db2.inc.php
+++ b/perf/perf-db2.inc.php
@@ -56,7 +56,7 @@ class perf_db2 extends adodb_perf{
 	);
 
 
-	function perf_db2(&$conn)
+	function __construct(&$conn)
 	{
 		$this->conn = $conn;
 	}

--- a/perf/perf-informix.inc.php
+++ b/perf/perf-informix.inc.php
@@ -61,7 +61,7 @@ class perf_informix extends adodb_perf{
 
 	);
 
-	function perf_informix(&$conn)
+	function __construct(&$conn)
 	{
 		$this->conn = $conn;
 	}

--- a/perf/perf-mssql.inc.php
+++ b/perf/perf-mssql.inc.php
@@ -65,7 +65,7 @@ class perf_mssql extends adodb_perf{
 	);
 
 
-	function perf_mssql(&$conn)
+	function __construct(&$conn)
 	{
 		if ($conn->dataProvider == 'odbc') {
 			$this->sql1 = 'sql1';

--- a/perf/perf-mssqlnative.inc.php
+++ b/perf/perf-mssqlnative.inc.php
@@ -65,7 +65,7 @@ class perf_mssqlnative extends adodb_perf{
 	);
 
 
-	function perf_mssqlnative(&$conn)
+	function __construct(&$conn)
 	{
 		if ($conn->dataProvider == 'odbc') {
 			$this->sql1 = 'sql1';

--- a/perf/perf-mysql.inc.php
+++ b/perf/perf-mysql.inc.php
@@ -81,7 +81,7 @@ class perf_mysql extends adodb_perf{
 		false
 	);
 
-	function perf_mysql(&$conn)
+	function __construct(&$conn)
 	{
 		$this->conn = $conn;
 	}

--- a/perf/perf-oci8.inc.php
+++ b/perf/perf-oci8.inc.php
@@ -198,7 +198,7 @@ FROM v\$parameter v1, v\$parameter v2 WHERE v1.name='log_archive_dest' AND v2.na
 	);
 
 
-	function perf_oci8(&$conn)
+	function __construct(&$conn)
 	{
 	global $gSQLBlockRows;
 

--- a/perf/perf-postgres.inc.php
+++ b/perf/perf-postgres.inc.php
@@ -87,7 +87,7 @@ class perf_postgres extends adodb_perf{
 		false
 	);
 
-	function perf_postgres(&$conn)
+	function __construct(&$conn)
 	{
 		$this->conn = $conn;
 	}

--- a/replicate/adodb-replicate.inc.php
+++ b/replicate/adodb-replicate.inc.php
@@ -97,7 +97,7 @@ class ADODB_Replicate {
 	// connSrc2 and connDest2 are only required if the db driver
 	// does not allow updates back to src db in first connection (the select connection),
 	// so we need 2nd connection
-	function ADODB_Replicate($connSrc, $connDest, $connSrc2=false, $connDest2=false)
+	function __construct($connSrc, $connDest, $connSrc2=false, $connDest2=false)
 	{
 
 		if (strpos($connSrc->databaseType,'odbtp') !== false) {

--- a/session/adodb-compress-bzip2.php
+++ b/session/adodb-compress-bzip2.php
@@ -73,7 +73,7 @@ class ADODB_Compress_Bzip2 {
 
 	/**
 	 */
-	function ADODB_Compress_Bzip2($block_size = null, $work_level = null, $min_length = null) {
+	function __construct($block_size = null, $work_level = null, $min_length = null) {
 		if (!is_null($block_size)) {
 			$this->setBlockSize($block_size);
 		}

--- a/session/adodb-compress-gzip.php
+++ b/session/adodb-compress-gzip.php
@@ -56,7 +56,7 @@ class ADODB_Compress_Gzip {
 
 	/**
 	 */
-	function ADODB_Compress_Gzip($level = null, $min_length = null) {
+	function __construct($level = null, $min_length = null) {
 		if (!is_null($level)) {
 			$this->setLevel($level);
 		}

--- a/session/adodb-encrypt-mcrypt.php
+++ b/session/adodb-encrypt-mcrypt.php
@@ -69,7 +69,7 @@ class ADODB_Encrypt_MCrypt {
 
 	/**
 	 */
-	function ADODB_Encrypt_MCrypt($cipher = null, $mode = null, $source = null) {
+	function __construct($cipher = null, $mode = null, $source = null) {
 		if (!$cipher) {
 			$cipher = MCRYPT_RIJNDAEL_256;
 		}


### PR DESCRIPTION
PHP 7 will emit E_DEPRECATED whenever a PHP 4 constructor is defined.