### PR TITLE
Strict Standards - incompatible function declarations

### DIFF
--- a/drivers/adodb-ado.inc.php
+++ b/drivers/adodb-ado.inc.php
@@ -147,7 +147,7 @@ class ADODB_ado extends ADOConnection {
 
 */
 
-	function MetaTables()
+	function MetaTables($ttype = false, $showSchema = false, $mask = false)
 	{
 		$arr= array();
 		$dbc = $this->_connectionID;

--- a/drivers/adodb-ado5.inc.php
+++ b/drivers/adodb-ado5.inc.php
@@ -172,7 +172,7 @@ class ADODB_ado extends ADOConnection {
 
 */
 
-	function MetaTables()
+	function MetaTables($ttype = false, $showSchema = false, $mask = false)
 	{
 		$arr= array();
 		$dbc = $this->_connectionID;

--- a/drivers/adodb-ads.inc.php
+++ b/drivers/adodb-ads.inc.php
@@ -136,7 +136,7 @@ class ADODB_ads extends ADOConnection {
 
 
         // returns true or false
-        function CreateSequence( $seqname,$start=1)
+        function CreateSequence($seqname = 'adodbseq', $start = 1)
   {
                 $res =  $this->Execute("CREATE TABLE $seqname ( ID autoinc( 1 ) ) IN DATABASE");
                 if(!$res){
@@ -149,7 +149,7 @@ class ADODB_ads extends ADOConnection {
         }
 
         // returns true or false
-        function DropSequence($seqname)
+        function DropSequence($seqname = 'adodbseq')
   {
                 $res = $this->Execute("DROP TABLE $seqname");
                 if(!$res){
@@ -164,7 +164,7 @@ class ADODB_ads extends ADOConnection {
   // returns the generated ID or false
         // checks if the table already exists, else creates the table and inserts a record into the table
         // and gets the ID number of the last inserted record.
-        function GenID($seqname,$start=1)
+        function GenID($seqname = 'adodbseq', $start = 1)
         {
                 $go = $this->Execute("select * from $seqname");
                 if (!$go){
@@ -254,7 +254,7 @@ class ADODB_ads extends ADOConnection {
 
   // Returns tables,Views or both on succesfull execution. Returns
         // tables by default on succesfull execustion.
-  function &MetaTables($ttype)
+  function &MetaTables($ttype = false, $showSchema = false, $mask = false)
   {
           $recordSet1 = $this->Execute("select * from system.tables");
                 if(!$recordSet1){
@@ -294,7 +294,7 @@ class ADODB_ads extends ADOConnection {
 
   }
 
-        function &MetaPrimaryKeys($table)
+        function &MetaPrimaryKeys($table, $owner = false)
   {
           $recordSet = $this->Execute("select table_primary_key from system.tables where name='$table'");
                 if(!$recordSet){
@@ -378,7 +378,7 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
     }
   }
 
-  function &MetaColumns($table)
+  function &MetaColumns($table, $normalize = true)
   {
   global $ADODB_FETCH_MODE;
 
@@ -486,7 +486,7 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
   }
 
         // Returns an array of columns names for a given table
-        function &MetaColumnNames($table)
+        function &MetaColumnNames($table, $numIndexes = false, $useattnum = false)
         {
                 $recordSet = $this->Execute("select name from system.columns where parent='$table'");
                 if(!$recordSet){

--- a/drivers/adodb-csv.inc.php
+++ b/drivers/adodb-csv.inc.php
@@ -79,7 +79,7 @@ class ADODB_csv extends ADOConnection {
 
 
 	// parameters use PostgreSQL convention, not MySQL
-	function SelectLimit($sql,$nrows=-1,$offset=-1)
+	function SelectLimit($sql, $nrows = -1, $offset = -1, $inputarr = false, $secs2cache = 0)
 	{
 	global $ADODB_FETCH_MODE;
 

--- a/drivers/adodb-db2.inc.php
+++ b/drivers/adodb-db2.inc.php
@@ -134,7 +134,7 @@ class ADODB_db2 extends ADOConnection {
 	}
 
 	// format and return date string in database timestamp format
-	function DBTimeStamp($ts)
+	function DBTimeStamp($ts, $isfld = false)
 	{
 		if (empty($ts) && $ts !== 0) return 'null';
 		if (is_string($ts)) $ts = ADORecordSet::UnixTimeStamp($ts);
@@ -233,13 +233,13 @@ class ADODB_db2 extends ADOConnection {
 		return true;
 	}
 
-	function DropSequence($seqname)
+	function DropSequence($seqname = 'adodbseq')
 	{
 		if (empty($this->_dropSeqSQL)) return false;
 		return $this->Execute(sprintf($this->_dropSeqSQL,$seqname));
 	}
 
-	function SelectLimit($sql,$nrows=-1,$offset=-1,$inputArr=false)
+	function SelectLimit($sql, $nrows = -1, $offset = -1, $inputArr = false, $secs2cache = 0)
 	{
 		$nrows = (integer) $nrows;
 		if ($offset <= 0) {
@@ -333,7 +333,7 @@ class ADODB_db2 extends ADOConnection {
 		return $ret;
 	}
 
-	function MetaPrimaryKeys($table)
+	function MetaPrimaryKeys($table, $owner = false)
 	{
 	global $ADODB_FETCH_MODE;
 
@@ -409,7 +409,7 @@ class ADODB_db2 extends ADOConnection {
 	}
 
 
-	function MetaTables($ttype=false,$schema=false)
+	function MetaTables($ttype = false, $schema = false, $mask = false)
 	{
 	global $ADODB_FETCH_MODE;
 

--- a/drivers/adodb-db2oci.inc.php
+++ b/drivers/adodb-db2oci.inc.php
@@ -169,7 +169,7 @@ class ADODB_db2oci extends ADODB_db2 {
 	}
 
 
-	function MetaTables($ttype=false,$schema=false)
+	function MetaTables($ttype = false, $schema = false, $mask = false)
 	{
 	global $ADODB_FETCH_MODE;
 

--- a/drivers/adodb-db2ora.inc.php
+++ b/drivers/adodb-db2ora.inc.php
@@ -58,7 +58,7 @@ class ADODB_db2oci extends ADODB_db2 {
 	}
 
 
-	function _Execute($sql, $inputarr)
+	function _Execute($sql, $inputarr = false)
 	{
 		if ($inputarr) list($sql,$inputarr) = _colonscope($sql, $inputarr);
 		return parent::_Execute($sql, $inputarr);

--- a/drivers/adodb-ibase.inc.php
+++ b/drivers/adodb-ibase.inc.php
@@ -268,14 +268,14 @@ class ADODB_ibase extends ADOConnection {
 	}
 
 
-	function CreateSequence($seqname,$startID=1)
+	function CreateSequence($seqname = 'adodbseq', $startID = 1)
 	{
 		$ok = $this->Execute(("INSERT INTO RDB\$GENERATORS (RDB\$GENERATOR_NAME) VALUES (UPPER('$seqname'))" ));
 		if (!$ok) return false;
 		return $this->Execute("SET GENERATOR $seqname TO ".($startID-1).';');
 	}
 
-	function DropSequence($seqname)
+	function DropSequence($seqname = 'adodbseq')
 	{
 		$seqname = strtoupper($seqname);
 		$this->Execute("delete from RDB\$GENERATORS where RDB\$GENERATOR_NAME='$seqname'");

--- a/drivers/adodb-ldap.inc.php
+++ b/drivers/adodb-ldap.inc.php
@@ -349,7 +349,7 @@ class ADORecordSet_ldap extends ADORecordSet{
 		return $results;
 	}
 
-	function GetRowAssoc()
+	function GetRowAssoc($upper = ADODB_ASSOC_CASE)
 	{
 		$results = array();
 		foreach ( $this->fields as $k=>$v ) {

--- a/drivers/adodb-mssqlpo.inc.php
+++ b/drivers/adodb-mssqlpo.inc.php
@@ -33,7 +33,7 @@ class ADODB_mssqlpo extends ADODB_mssql {
 		ADODB_mssql::ADODB_mssql();
 	}
 
-	function PrepareSP($sql)
+	function PrepareSP($sql, $param = true)
 	{
 		if (!$this->_has_mssql_init) {
 			ADOConnection::outp( "PrepareSP: mssql_init only available since PHP 4.1.0");

--- a/drivers/adodb-odbc.inc.php
+++ b/drivers/adodb-odbc.inc.php
@@ -132,7 +132,7 @@ class ADODB_odbc extends ADOConnection {
 	}
 
 	var $_dropSeqSQL = 'drop table %s';
-	function DropSequence($seqname)
+	function DropSequence($seqname = 'adodbseq')
 	{
 		if (empty($this->_dropSeqSQL)) return false;
 		return $this->Execute(sprintf($this->_dropSeqSQL,$seqname));

--- a/drivers/adodb-odbc_db2.inc.php
+++ b/drivers/adodb-odbc_db2.inc.php
@@ -278,7 +278,7 @@ class ADODB_ODBC_DB2 extends ADODB_odbc {
 	}
 
 
-	function SelectLimit($sql,$nrows=-1,$offset=-1,$inputArr=false)
+	function SelectLimit($sql, $nrows = -1, $offset = -1, $inputArr = false, $secs2cache = 0)
 	{
 		$nrows = (integer) $nrows;
 		if ($offset <= 0) {

--- a/drivers/adodb-odbc_mssql.inc.php
+++ b/drivers/adodb-odbc_mssql.inc.php
@@ -252,7 +252,7 @@ order by constraint_name, referenced_table_name, keyno";
 
 	// "Stein-Aksel Basma" <basma@accelero.no>
 	// tested with MSSQL 2000
-	function MetaPrimaryKeys($table)
+	function MetaPrimaryKeys($table, $owner = false)
 	{
 	global $ADODB_FETCH_MODE;
 

--- a/drivers/adodb-odbc_oracle.inc.php
+++ b/drivers/adodb-odbc_oracle.inc.php
@@ -36,7 +36,7 @@ class  ADODB_odbc_oracle extends ADODB_odbc {
 		$this->ADODB_odbc();
 	}
 
-	function MetaTables()
+	function MetaTables($ttype = false, $showSchema = false, $mask = false)
 	{
 		$false = false;
 		$rs = $this->Execute($this->metaTablesSQL);

--- a/drivers/adodb-odbtp.inc.php
+++ b/drivers/adodb-odbtp.inc.php
@@ -120,7 +120,7 @@ class ADODB_odbtp extends ADOConnection{
 		return $this->Execute("insert into adodb_seq values('$seqname',$start)");
 	}
 
-	function DropSequence($seqname)
+	function DropSequence($seqname = 'adodbseq')
 	{
 		if (empty($this->_dropSeqSQL)) return false;
 		return $this->Execute(sprintf($this->_dropSeqSQL,$seqname));
@@ -475,7 +475,7 @@ class ADODB_odbtp extends ADOConnection{
 		return array($sql,$stmt,false);
 	}
 
-	function PrepareSP($sql)
+	function PrepareSP($sql, $param = true)
 	{
 		if (!$this->_canPrepareSP) return $sql; // Can't prepare procedures
 

--- a/drivers/adodb-oracle.inc.php
+++ b/drivers/adodb-oracle.inc.php
@@ -32,7 +32,7 @@ class ADODB_oracle extends ADOConnection {
 	}
 
 	// format and return date string in database date format
-	function DBDate($d)
+	function DBDate($d, $isfld = false)
 	{
 		if (is_string($d)) $d = ADORecordSet::UnixDate($d);
 		if (is_object($d)) $ds = $d->format($this->fmtDate);
@@ -41,7 +41,7 @@ class ADODB_oracle extends ADOConnection {
 	}
 
 	// format and return date string in database timestamp format
-	function DBTimeStamp($ts)
+	function DBTimeStamp($ts, $isfld = false)
 	{
 
 		if (is_string($ts)) $ts = ADORecordSet::UnixTimeStamp($ts);
@@ -303,7 +303,7 @@ class ADORecordset_oracle extends ADORecordSet {
 		   return @ora_close($this->_queryID);
    }
 
-	function MetaType($t,$len=-1)
+	function MetaType($t, $len = -1, $fieldobj = false)
 	{
 		if (is_object($t)) {
 			$fieldobj = $t;

--- a/drivers/adodb-sapdb.inc.php
+++ b/drivers/adodb-sapdb.inc.php
@@ -46,7 +46,7 @@ class ADODB_SAPDB extends ADODB_odbc {
 		return $info;
 	}
 
-	function MetaPrimaryKeys($table)
+	function MetaPrimaryKeys($table, $owner = false)
 	{
 		$table = $this->Quote(strtoupper($table));
 
@@ -92,7 +92,7 @@ class ADODB_SAPDB extends ADODB_odbc {
         return $indexes;
 	}
 
- 	function MetaColumns ($table)
+	function MetaColumns ($table, $normalize = true)
 	{
 		global $ADODB_FETCH_MODE;
 		$save = $ADODB_FETCH_MODE;
@@ -140,7 +140,7 @@ class ADODB_SAPDB extends ADODB_odbc {
 		return $retarr;
 	}
 
-	function MetaColumnNames($table)
+	function MetaColumnNames($table, $numIndexes = false, $useattnum = false)
 	{
 		$table = $this->Quote(strtoupper($table));
 

--- a/drivers/adodb-sqlite.inc.php
+++ b/drivers/adodb-sqlite.inc.php
@@ -288,7 +288,7 @@ class ADODB_sqlite extends ADOConnection {
 	}
 
 	var $_dropSeqSQL = 'drop table %s';
-	function DropSequence($seqname)
+	function DropSequence($seqname = 'adodbseq')
 	{
 		if (empty($this->_dropSeqSQL)) {
 			return false;
@@ -302,7 +302,7 @@ class ADODB_sqlite extends ADOConnection {
 		return @sqlite_close($this->_connectionID);
 	}
 
-	function MetaIndexes($table, $primary = FALSE, $owner=false, $owner = false)
+	function MetaIndexes($table, $primary = FALSE, $owner = false)
 	{
 		$false = false;
 		// save old fetch mode

--- a/drivers/adodb-sqlite3.inc.php
+++ b/drivers/adodb-sqlite3.inc.php
@@ -271,7 +271,7 @@ class ADODB_sqlite3 extends ADOConnection {
 	}
 
 	var $_dropSeqSQL = 'drop table %s';
-	function DropSequence($seqname)
+	function DropSequence($seqname = 'adodbseq')
 	{
 		if (empty($this->_dropSeqSQL)) {
 			return false;
@@ -285,7 +285,7 @@ class ADODB_sqlite3 extends ADOConnection {
 		return $this->_connectionID->close();
 	}
 
-	function MetaIndexes($table, $primary = FALSE, $owner=false, $owner = false)
+	function MetaIndexes($table, $primary = FALSE, $owner = false)
 	{
 		$false = false;
 		// save old fetch mode

--- a/drivers/adodb-sybase.inc.php
+++ b/drivers/adodb-sybase.inc.php
@@ -278,7 +278,7 @@ class ADODB_sybase extends ADOConnection {
 	# Added 2003-10-07 by Chris Phillipson
 	# Used ASA SQL Reference Manual -- http://sybooks.sybase.com/onlinebooks/group-aw/awg0800e/dbrfen8/@ebt-link;pt=5981;uf=0?target=0;window=new;showtoc=true;book=dbrfen8
 	# to convert similar Microsoft SQL*Server (mssql) API into Sybase compatible version
-	function MetaPrimaryKeys($table)
+	function MetaPrimaryKeys($table, $owner = false)
 	{
 		$sql = "SELECT c.column_name " .
 			   "FROM syscolumn c, systable t " .

--- a/drivers/adodb-vfp.inc.php
+++ b/drivers/adodb-vfp.inc.php
@@ -77,7 +77,7 @@ class  ADORecordSet_vfp extends ADORecordSet_odbc {
 		return $this->ADORecordSet_odbc($id,$mode);
 	}
 
-	function MetaType($t,$len=-1)
+	function MetaType($t, $len = -1, $fieldobj = false)
 	{
 		if (is_object($t)) {
 			$fieldobj = $t;


### PR DESCRIPTION
Most are easy to fix, but a few are not.

drivers/adodb-sqlanywhere.inc.php
PHP Strict standards:  Declaration of ADODB_sqlanywhere::UpdateBlob() should be compatible with ADODB_odbc::UpdateBlob($table, $column, $val, $where, $blobtype = 'BLOB') in /Users/nicols/git/ext/ADOdb/drivers/adodb-sqlanywhere.inc.php on line 55
PHP Stack trace:
PHP   1. {main}() /Users/nicols/git/ext/ADOdb/test.php:0
PHP   2. require_once() /Users/nicols/git/ext/ADOdb/test.php:14

Strict standards: Declaration of ADODB_sqlanywhere::UpdateBlob() should be compatible with ADODB_odbc::UpdateBlob($table, $column, $val, $where, $blobtype = 'BLOB') in /Users/nicols/git/ext/ADOdb/drivers/adodb-sqlanywhere.inc.php on line 55

Call Stack:
    0.0002     227864   1. {main}() /Users/nicols/git/ext/ADOdb/test.php:0
    0.0080    1383440   2. require_once('/Users/nicols/git/ext/ADOdb/drivers/adodb-sqlanywhere.inc.php') /Users/nicols/git/ext/ADOdb/test.php:14

drivers/adodb-text.inc.php
PHP Strict standards:  Declaration of ADODB_text::Connect() should be compatible with ADOConnection::Connect($argHostname = '', $argUsername = '', $argPassword = '', $argDatabaseName = '', $forceNew = false) in /Users/nicols/git/ext/ADOdb/drivers/adodb-text.inc.php on line 76
PHP Stack trace:
PHP   1. {main}() /Users/nicols/git/ext/ADOdb/test.php:0
PHP   2. require_once() /Users/nicols/git/ext/ADOdb/test.php:14

Strict standards: Declaration of ADODB_text::Connect() should be compatible with ADOConnection::Connect($argHostname = '', $argUsername = '', $argPassword = '', $argDatabaseName = '', $forceNew = false) in /Users/nicols/git/ext/ADOdb/drivers/adodb-text.inc.php on line 76

Call Stack:
    0.0002     227856   1. {main}() /Users/nicols/git/ext/ADOdb/test.php:0
    0.0059    1420536   2. require_once('/Users/nicols/git/ext/ADOdb/drivers/adodb-text.inc.php') /Users/nicols/git/ext/ADOdb/test.php:14

PHP Strict standards:  Declaration of ADODB_text::PConnect() should be compatible with ADOConnection::PConnect($argHostname = '', $argUsername = '', $argPassword = '', $argDatabaseName = '') in /Users/nicols/git/ext/ADOdb/drivers/adodb-text.inc.php on line 76
PHP Stack trace:
PHP   1. {main}() /Users/nicols/git/ext/ADOdb/test.php:0
PHP   2. require_once() /Users/nicols/git/ext/ADOdb/test.php:14

Strict standards: Declaration of ADODB_text::PConnect() should be compatible with ADOConnection::PConnect($argHostname = '', $argUsername = '', $argPassword = '', $argDatabaseName = '') in /Users/nicols/git/ext/ADOdb/drivers/adodb-text.inc.php on line 76

Call Stack:
    0.0002     227856   1. {main}() /Users/nicols/git/ext/ADOdb/test.php:0
    0.0059    1420536   2. require_once('/Users/nicols/git/ext/ADOdb/drivers/adodb-text.inc.php') /Users/nicols/git/ext/ADOdb/test.php:14