### PR TITLE
table <opt> for mysqli, enable ALTER TABLE queries

### DIFF
--- a/adodb-xmlschema03.inc.php
+++ b/adodb-xmlschema03.inc.php
@@ -505,7 +505,11 @@ class dbTable extends dbObject {
 	*/
 	function addTableOpt( $opt ) {
 		if(isset($this->currentPlatform)) {
-			$this->opts[$this->parent->db->databaseType] = $opt;
+			#$this->opts[$this->parent->db->databaseType] = $opt;
+			# fix for: if driver is mysqli, but 'platform' is mysql and you want mysqlspecific table create options like
+			# <opt>DEFAULT CHARSET=utf8</opt> in the xml or dbspecific:
+			# <opt platform="mysql">DEFAULT CHARSET=utf8</opt> in the xml
+			$this->opts[$this->parent->db->dataProvider] = $opt;
 		}
 		return $this->opts;
 	}
@@ -1242,6 +1246,9 @@ class dbQuerySet extends dbObject {
 					$query = $this->prefixQuery( '/^\s*((?is)INSERT\s+(INTO\s+)?)((\w+\s*,?\s*)+)(\s.*$)/', $query, $xmls->objectPrefix );
 					$query = $this->prefixQuery( '/^\s*((?is)UPDATE\s+(FROM\s+)?)((\w+\s*,?\s*)+)(\s.*$)/', $query, $xmls->objectPrefix );
 					$query = $this->prefixQuery( '/^\s*((?is)DELETE\s+(FROM\s+)?)((\w+\s*,?\s*)+)(\s.*$)/', $query, $xmls->objectPrefix );
+
+					// enable ALTER TABLE queries, just adapted from above..
+					$query = $this->prefixQuery( '/^\s*((?is)ALTER\s+(TABLE\s+)?)((\w+\s*,?\s*)+)(\s.*$)/', $query, $xmls->objectPrefix );
 
 					// SELECT statements aren't working yet
 					#$data = preg_replace( '/(?ias)(^\s*SELECT\s+.*\s+FROM)\s+(\W\s*,?\s*)+((?i)\s+WHERE.*$)/', "\1 $prefix\2 \3", $data );

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,1 @@
+<?php /* nothing at the moment */ ?>

--- a/tests/phpunit/phpunit_mysql.xml
+++ b/tests/phpunit/phpunit_mysql.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/phpunit/bootstrap.php" colors="true">
+<php>
+<var name="db_dsn" value="mysql:dbname=adodb_test;host=localhost"/>
+<var name="db_type" value="mysqli"/>
+<var name="db_dbname" value="adodb_test"/>
+<var name="db_prefix" value="adodb_"/>
+<var name="db_host" value="localhost"/>
+<var name="db_user" value="root"/>
+<var name="db_pass" value=""/>
+</php>
+<testsuites>
+<testsuite name="ADOdb Test Suite">
+<directory>./tests/phpunit/</directory>
+</testsuite>
+</testsuites>
+<filter>
+<whitelist>
+<directory>./</directory>
+<exclude>
+<directory>./tests</directory>
+</exclude>
+</whitelist>
+</filter>
+</phpunit>

--- a/tests/phpunit/phpunit_pgsql.xml
+++ b/tests/phpunit/phpunit_pgsql.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/phpunit/bootstrap.php" colors="true">
+<php>
+<var name="db_dsn" value="pgsql:dbname=adodb_test;host=localhost"/>
+<var name="db_type" value="pgsql"/>
+<var name="db_dbname" value="adodb_test"/>
+<var name="db_prefix" value="adodb_"/>
+<var name="db_host" value="localhost"/>
+<var name="db_user" value="postgres"/>
+<var name="db_pass" value=""/>
+</php>
+<testsuites>
+<testsuite name="ADOdb Test Suite">
+<directory>./tests/phpunit/</directory>
+</testsuite>
+</testsuites>
+<filter>
+<whitelist>
+<directory>./</directory>
+<exclude>
+<directory>./tests</directory>
+</exclude>
+</whitelist>
+</filter>
+</phpunit>


### PR DESCRIPTION
When a driver was used were $databaseType != $dataProvider (for instance mysqli vs. mysql) , the <opt></opt> tags in xml were ignored.

So this was ignored in the xml:
```xml
<table name="example">
<field name="content" type="C" size="100"></field>
<opt>DEFAULT CHARSET=utf8</opt>
</table>
```
Or this because the opt of example is dbspecific:
```xml
<table name="example">
<field name="content" type="C" size="100"></field>
<opt platform="mysql">DEFAULT CHARSET=utf8</opt>
</table>
```

For fixing a table on install if table <opt> not used/possible or on a upgrade the ALTER TABLE schould be possible within the xmlschema03.
```xml
<sql>
<query platform="mysql">ALTER TABLE example CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci</query>
</sql>
```