### PR TITLE
Making ? (parameter) detection in queries more robust

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1102,6 +1102,7 @@ if (!defined('_ADODB_LAYER')) {
           $j++;
         }
         $sql = implode("'", $sql);  // restore original query
+				
 
 				// Get number of parameters (tokens)
 				$nparams = sizeof($sqlarr)-1;

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1076,8 +1076,34 @@ if (!defined('_ADODB_LAYER')) {
 			unset($element0);
 
 			if (!is_array($sql) && !$this->_bindInputArray) {
-				// @TODO this would consider a '?' within a string as a parameter...
-				$sqlarr = explode('?',$sql);
+				// Normalize any hardcoded strings in the query to single quotes
+				$sql = explode("\\\"", $sql);	// protect escaped double quotes
+				while(list(, $x) = each($sql))
+				  $sqlClean[] = str_replace('"', "'", $x);
+				$sql = implode('\\\"', $sqlClean);	// restore escaped double quotes
+
+				// Split by tokens, ignoring tokens in quotes
+				$sql = explode("'", $sql);
+				$j = 0; $prevSeg = 0;
+				while(list(, $v) = each($sql)) {
+				  if($j%2 == 0) {
+				    // if even, we're outside the quotes
+				    $exp = explode("?", $v);
+				    $sqlarr[$prevSeg] .= $exp[0];
+				    unset($exp[0]);
+				    array_merge($sqlarr, $exp);
+				    while(list(, $w) = each($exp))
+				      $sqlarr[] = $w;
+				    $prevSeg = $j + (count($exp));
+				  } else {
+				    // if odd, we're inside the quotes
+				    $sqlarr[$prevSeg] .= "'".$v."'";
+				  }
+				  $j++;
+				}
+				$sql = implode("'", $sql);	// restore original query
+
+				// Get number of parameters (tokens)
 				$nparams = sizeof($sqlarr)-1;
 
 				// If there are no '?' tokens in the query and there is a an input array (has to be

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1076,32 +1076,32 @@ if (!defined('_ADODB_LAYER')) {
 			unset($element0);
 
 			if (!is_array($sql) && !$this->_bindInputArray) {
-				// Normalize any hardcoded strings in the query to single quotes
-				$sql = explode("\\\"", $sql);	// protect escaped double quotes
-				while(list(, $x) = each($sql))
-				  $sqlClean[] = str_replace('"', "'", $x);
-				$sql = implode('\\\"', $sqlClean);	// restore escaped double quotes
+        // Normalize any hardcoded strings in the query to single quotes
+        $sql = explode("\\\"", $sql); // protect escaped double quotes
+        while(list(, $x) = each($sql))
+          $sqlClean[] = str_replace('"', "'", $x);
+        $sql = implode('\\\"', $sqlClean);  // restore escaped double quotes
 
-				// Split by tokens, ignoring tokens in quotes
-				$sql = explode("'", $sql);
-				$j = 0; $prevSeg = 0;
-				while(list(, $v) = each($sql)) {
-				  if($j%2 == 0) {
-				    // if even, we're outside the quotes
-				    $exp = explode("?", $v);
-				    $sqlarr[$prevSeg] .= $exp[0];
-				    unset($exp[0]);
-				    array_merge($sqlarr, $exp);
-				    while(list(, $w) = each($exp))
-				      $sqlarr[] = $w;
-				    $prevSeg = $j + (count($exp));
-				  } else {
-				    // if odd, we're inside the quotes
-				    $sqlarr[$prevSeg] .= "'".$v."'";
-				  }
-				  $j++;
-				}
-				$sql = implode("'", $sql);	// restore original query
+        // Split by tokens, ignoring tokens in quotes
+        $sql = explode("'", $sql);
+        $j = 0; $prevSeg = 0;
+        while(list(, $v) = each($sql)) {
+          if($j%2 == 0) {
+            // if even, we're outside the quotes
+            $exp = explode("?", $v);
+            $sqlarr[$prevSeg] .= $exp[0];
+            unset($exp[0]);
+            array_merge($sqlarr, $exp);
+            while(list(, $w) = each($exp))
+              $sqlarr[] = $w;
+            $prevSeg += count($exp);
+          } else {
+            // if odd, we're inside the quotes
+            $sqlarr[$prevSeg] .= "'".$v."'";
+          }
+          $j++;
+        }
+        $sql = implode("'", $sql);  // restore original query
 
 				// Get number of parameters (tokens)
 				$nparams = sizeof($sqlarr)-1;

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1076,32 +1076,32 @@ if (!defined('_ADODB_LAYER')) {
 			unset($element0);
 
 			if (!is_array($sql) && !$this->_bindInputArray) {
-        		// Normalize any hardcoded strings in the query to single quotes
-        		$sql = explode("\\\"", $sql); // protect escaped double quotes
-        		while(list(, $x) = each($sql))
-        		  $sqlClean[] = str_replace('"', "'", $x);
-        		$sql = implode('\\\"', $sqlClean);  // restore escaped double quotes
+				// Normalize any hardcoded strings in the query to single quotes
+				$sql = explode("\\\"", $sql);	// protect escaped double quotes
+				while(list(, $x) = each($sql))
+					$sqlClean[] = str_replace('"', "'", $x);
+				$sql = implode('\\\"', $sqlClean);	// restore escaped double quotes
 				
-        		// Split by tokens, ignoring tokens in quotes
-        		$sql = explode("'", $sql);
-        		$j = 0; $prevSeg = 0;
-        		while(list(, $v) = each($sql)) {
-        		  if($j%2 == 0) {
-        		    // if even, we're outside the quotes
-        		    $exp = explode("?", $v);
-        		    $sqlarr[$prevSeg] .= $exp[0];
-        		    unset($exp[0]);
-        		    array_merge($sqlarr, $exp);
-        		    while(list(, $w) = each($exp))
-        		      $sqlarr[] = $w;
-        		    $prevSeg += count($exp);
-        		  } else {
-        		    // if odd, we're inside the quotes
-        		    $sqlarr[$prevSeg] .= "'".$v."'";
-        		  }
-        		  $j++;
-        		}
-        		$sql = implode("'", $sql);  // restore original query
+				// Split by tokens, ignoring tokens in quotes
+				$sql = explode("'", $sql);
+				$j = 0; $prevSeg = 0;
+				while(list(, $v) = each($sql)) {
+					if($j%2 == 0) {
+						// if even, we're outside the quotes
+						$exp = explode("?", $v);
+						$sqlarr[$prevSeg] .= $exp[0];
+						unset($exp[0]);
+						array_merge($sqlarr, $exp);
+						while(list(, $w) = each($exp))
+							$sqlarr[] = $w;
+						$prevSeg += count($exp);
+					} else {
+						// if odd, we're inside the quotes
+						$sqlarr[$prevSeg] .= "'".$v."'";
+					}
+					$j++;
+				}
+				$sql = implode("'", $sql);	// restore original query
 				
 
 				// Get number of parameters (tokens)

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1076,32 +1076,32 @@ if (!defined('_ADODB_LAYER')) {
 			unset($element0);
 
 			if (!is_array($sql) && !$this->_bindInputArray) {
-        // Normalize any hardcoded strings in the query to single quotes
-        $sql = explode("\\\"", $sql); // protect escaped double quotes
-        while(list(, $x) = each($sql))
-          $sqlClean[] = str_replace('"', "'", $x);
-        $sql = implode('\\\"', $sqlClean);  // restore escaped double quotes
-
-        // Split by tokens, ignoring tokens in quotes
-        $sql = explode("'", $sql);
-        $j = 0; $prevSeg = 0;
-        while(list(, $v) = each($sql)) {
-          if($j%2 == 0) {
-            // if even, we're outside the quotes
-            $exp = explode("?", $v);
-            $sqlarr[$prevSeg] .= $exp[0];
-            unset($exp[0]);
-            array_merge($sqlarr, $exp);
-            while(list(, $w) = each($exp))
-              $sqlarr[] = $w;
-            $prevSeg += count($exp);
-          } else {
-            // if odd, we're inside the quotes
-            $sqlarr[$prevSeg] .= "'".$v."'";
-          }
-          $j++;
-        }
-        $sql = implode("'", $sql);  // restore original query
+        		// Normalize any hardcoded strings in the query to single quotes
+        		$sql = explode("\\\"", $sql); // protect escaped double quotes
+        		while(list(, $x) = each($sql))
+        		  $sqlClean[] = str_replace('"', "'", $x);
+        		$sql = implode('\\\"', $sqlClean);  // restore escaped double quotes
+				
+        		// Split by tokens, ignoring tokens in quotes
+        		$sql = explode("'", $sql);
+        		$j = 0; $prevSeg = 0;
+        		while(list(, $v) = each($sql)) {
+        		  if($j%2 == 0) {
+        		    // if even, we're outside the quotes
+        		    $exp = explode("?", $v);
+        		    $sqlarr[$prevSeg] .= $exp[0];
+        		    unset($exp[0]);
+        		    array_merge($sqlarr, $exp);
+        		    while(list(, $w) = each($exp))
+        		      $sqlarr[] = $w;
+        		    $prevSeg += count($exp);
+        		  } else {
+        		    // if odd, we're inside the quotes
+        		    $sqlarr[$prevSeg] .= "'".$v."'";
+        		  }
+        		  $j++;
+        		}
+        		$sql = implode("'", $sql);  // restore original query
 				
 
 				// Get number of parameters (tokens)


### PR DESCRIPTION
This patch makes changes in commit 1a4befc14c52a96591eca2424ff87eabe7d233e2 a little less "destructive" and more in line with the existing parameters mismatch errors; and makes the "?" token (parameter) detection in queries more robust.

1) 1a4befc14c52a96591eca2424ff87eabe7d233e2 would throw an exception / error and return false if a query with no parameters was passed alongside a non-empty input array. This patch makes it simply throw an error and continue, but IGNORING the input array completely. Disabling error handling / exceptions will, thus, not break an application, but will still behave correctly.

2) Previously, queries were simply exploded over "?" token as part of the query parsing flow. This means that having a hardcoded string in a query, with a ? in it could result in unpredictable behaviour. This has been dealt away with, by first normalizing the query so it only uses single quotes (while protecting double-escaped double quotes), then exploding it by quotes, then processing the parts that are outside of quotes normally (explode by "?") while ignoring the parts that are inside quotes.

No regexps were used, only array manipulations and str_\* functions.

It's not perfect, but it should be a tiny bit more robust than the original version.
It's been tested on an actual live app (in a dev environment) and via a few ad-hoc test scripts, but i might've missed something - more thorough testing is advised.
