### PR TITLE
Return -1 by default, for sqlite3 _numOfRows

### DIFF
--- a/drivers/adodb-sqlite3.inc.php
+++ b/drivers/adodb-sqlite3.inc.php
@@ -394,7 +394,6 @@ class ADORecordset_sqlite3 extends ADORecordSet {
 
 	function _initrs()
 	{
-		$this->_numOfRows = 1;
 		$this->_numOfFields = $this->_queryID->numColumns();
 
 	}


### PR DESCRIPTION
This relies on the built-in ability to rely on ADODB_COUNTRECS.

Before this patch, we were setting _numOfRows to positive 1, which meant
that any query that checked how many rows were available in a queryset
would see literally the number 1, which was not accurate for queries that
returned 0 rows or queries that returned more rows.

Note that returning -1 is also what the ADOdb Oracle driver does, for
example. In the case of sqlite3, there appears to be no efficient
way to ask the PHP sqlite3 driver how many rows come back from
a query, so returning -1 is the best we can do.