### PR TITLE
Fix getAssoc() when request returned zero row

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -3434,7 +3434,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		}
 
 		// Determine whether the array is associative or 0-based numeric
-		$numIndex = array_keys($this->fields) == range(0, count($this->fields) - 1);
+		$numIndex = is_array($this->fields) && array_keys($this->fields) == range(0, count($this->fields) - 1);
 
 		$results = array();
 


### PR DESCRIPTION
Added an array to check whether $this->fields is an array before calling array_keys.
When the request returned zero rows $this->fields seems to be a boolean and not an array.
https://github.com/ADOdb/ADOdb/issues/162
