### PR TITLE
PDO compatibility methods fetch() and fetchColumn() for ADORecordSet

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -4414,6 +4414,43 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		return $this->_atLastPage;
 	}
 
+	/**
+	 * PDO compatibility function: fetch the next row
+	 *
+	 * @param $fetchmode =null ADODB_FETCH_{DEFAULT|ASSOC|NUM|BOTH}, default is to use currently selected fetch-mode
+	 * @return array|boolean false if there's nothing to fetch
+	 */
+	function &fetch($fetchmode=null) {
+		if (!is_null($fetchmode)) {
+			$save = $this->fetchMode;
+			$this->fetchMode = $fetchmode;
+		}
+		$row =& $this->FetchRow();
+		if (!is_null($fetchmode)) {
+			$this->fetchMode = $save;
+		}
+		return $row;
+	}
+
+	/**
+	 * PDO compatibility function: fetch the n-th column of the next row
+	 *
+	 * @param int $column_number =0
+	 * @return string|boolean false if there's nothing to fetch
+	 */
+	function fetchColumn($column_number=0)
+	{
+		if(!($row = $this->FetchRow())) {
+			return false;
+		}
+		while ($column_number-- >= 0) {
+			$ret = array_shift($row);
+
+			if ($this->fetchMode == ADODB_FETCH_BOTH) array_shift($row);
+		}
+		return $ret;
+	}
+
 } // end class ADORecordSet
 
 	//==============================================================================================


### PR DESCRIPTION
I was contributing to ADOdb before, mostly in PostgreSQL datadictionary. At some point John Lim stopped responding and our version became a fork. As ADOdb seems to be active again, I would like to contribute my modifications, if they make sense to you, and update our codebase (www.egroupware.org) to current ADOdb version. If everything is acceptable I would use composer to integrate ADOdb in EGroupware. I will publish my modifications as small pull requests. Here's the first one:

These two methods allow to use an ADOdb record-set, as you would a PDO one:
- fetch(), fetches next row: https://secure.php.net/manual/en/pdostatement.fetch.php
- fetchColumn(), fetches a single column from next row: https://secure.php.net/manual/en/pdostatement.fetchcolumn.php

Ralf