### PR TITLE
Allow to specify a column specific character set

### DIFF
--- a/datadict/datadict-mysql.inc.php
+++ b/datadict/datadict-mysql.inc.php
@@ -26,7 +26,7 @@ class ADODB2_mysql extends ADODB_DataDict {
 
 	function MetaType($t,$len=-1,$fieldobj=false)
 	{
-		
+
 		if (is_object($t)) {
 			$fieldobj = $t;
 			$t = $fieldobj->type;
@@ -114,6 +114,10 @@ class ADODB2_mysql extends ADODB_DataDict {
 	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
 	{
 		$suffix = '';
+		if (stripos($fconstraint, 'CHARACTER SET') === 0) {
+			$suffix .= ' '.$fconstraint;
+			unset($fconstraint);
+		}
 		if ($funsigned) $suffix .= ' UNSIGNED';
 		if ($fnotnull) $suffix .= ' NOT NULL';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";


### PR DESCRIPTION
Limiting index size is important for MySQL performance. This pull request allows eg. to create columns with ascii charset (1 byte instead of 3 for utf8), if content only requires ascii characters.

The patch (mis-)uses constrain parsing to specify the character set, eg.

`C(64) CONSTRAIN "CHARACTER SET ascii"`

Original goal was to keep ADOdb modifications to a minimum, but I could also change parser to understand something like `C(64) CHARACTER SET ascii` and pass it via an extra parameter to _CreateSuffix for data dictionaries supporting it.

Ralf
