### PR TITLE
Always name quote

### DIFF
--- a/adodb-datadict.inc.php
+++ b/adodb-datadict.inc.php
@@ -350,14 +350,13 @@ class ADODB_DataDict {
 			return $quote . $matches[1] . $quote;
 		}
 
-		// if name contains special characters, quote it
-		$regex = ($allowBrackets) ? $this->nameRegexBrackets : $this->nameRegex;
-
-		if ( !preg_match('/^[' . $regex . ']+$/', $name) ) {
-			return $quote . $name . $quote;
+		// allways quote column names to kope with column names being reserved words like eg. "timestamp"
+		// if brackets are allowed, quote only the rest,
+		// to allow to limit indexes on colums, eg "column(32)"
+		if ($allowBrackets && preg_match('/^(.*) *(\(\d+\))$/',$name,$matches)) {
+			return $quote . $matches[1] . $quote . ' '. $matches[2];
 		}
-
-		return $name;
+		return $quote . $name . $quote;
 	}
 
 	function TableName($name)
@@ -665,11 +664,11 @@ class ADODB_DataDict {
 			//-----------------
 			// Parse attributes
 			foreach($fld as $attr => $v) {
-				if ($attr == 2 && is_numeric($v)) 
+				if ($attr == 2 && is_numeric($v))
 					$attr = 'SIZE';
-				elseif ($attr == 2 && strtoupper($ftype) == 'ENUM') 
+				elseif ($attr == 2 && strtoupper($ftype) == 'ENUM')
 					$attr = 'ENUM';
-				else if (is_numeric($attr) && $attr > 1 && !is_numeric($v)) 
+				else if (is_numeric($attr) && $attr > 1 && !is_numeric($v))
 					$attr = strtoupper($v);
 
 				switch($attr) {
@@ -820,7 +819,7 @@ class ADODB_DataDict {
 			if (strlen($fprec)) $ftype .= ",".$fprec;
 			$ftype .= ')';
 		}
-		
+
 		/*
 		* Handle additional options
 		*/
@@ -833,12 +832,12 @@ class ADODB_DataDict {
 					case 'ENUM':
 					$ftype .= '(' . $value . ')';
 					break;
-					
+
 					default:
 				}
 			}
 		}
-		
+
 		return $ftype;
 	}
 

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -616,6 +616,11 @@ class ADODB_postgres64 extends ADOConnection{
 	{
 		global $ADODB_FETCH_MODE;
 
+		//if tablenames are quoted, remove the quotes as the tablenames here are used for comparsion of content of fields in postgres system tables
+		if (!empty($this->nameQuote) && !(strpos($table,$this->nameQuote)===false)) {
+			$table = str_replace($this->nameQuote,'',$table);
+		}
+
 		$schema = false;
 		$this->_findschema($table,$schema);
 

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -492,6 +492,9 @@ class ADODB_postgres64 extends ADOConnection{
 	{
 		global $ADODB_FETCH_MODE;
 
+		// table-name must NOT be quoted, otherwise we will not find any index
+		$table = str_replace($this->nameQuote,'',$table);
+
 		$schema = false;
 		$false = false;
 		$this->_findschema($table,$schema);


### PR DESCRIPTION
This pull-requests consists of two part:

a) new feature: always quote column and table names, instead of only if they contain special characters.
This allows to use reserved words of the database as column- or table-names eg. "group" or "timestamp".
I know this is a bad idea and we don't use that in our own software, but we have to create schemata for other projects we have no influence on too.

b) bug fix: PostgreSQL datadictionary queries columns and indexes from PostgreSQL's internal tables. If a table-name is quoted (either always because of above patch, or because it contains special chars!) the comparison will fail and no columns or indexes get reported.

As a workaround for a) we could already pass table- or column-name MySQL quoted eg. "`group`", which then get's unconditionally replaced by DB specific quotes in existing nameQuote implementation.
Then we would still run into bug fixed with b), which exists in current code-base independent of a).

Ralf