### PR TITLE
fix maria year values to not default to Y-m-d, and stay YYYY

### DIFF
--- a/adodb-datadict.inc.php
+++ b/adodb-datadict.inc.php
@@ -250,7 +250,7 @@ class ADODB_DataDict {
 		'LONGBINARY' => 'B',
 		'B' => 'B',
 		##
-		'YEAR' => 'D', // mysql
+		'YEAR' => 'Y', // mysql
 		'DATE' => 'D',
 		'D' => 'D',
 		##

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -1072,6 +1072,10 @@ function _adodb_column_sql(&$zthis, $action, $type, $fname, $fnameq, $arrFields,
 			if (!is_numeric($val)) $val = (integer) $val;
 		    break;
 
+		case "Y":
+			$val = $arrFields[$fname];
+			break;
+
 		default:
 			$val = str_replace(array("'"," ","("),"",$arrFields[$fname]); // basic sql injection defence
 			if (empty($val)) $val = '0';

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -4282,7 +4282,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 			'LONGBINARY' => 'B',
 			'B' => 'B',
 			##
-			'YEAR' => 'D', // mysql
+			'YEAR' => 'Y', // mysql
 			'DATE' => 'D',
 			'D' => 'D',
 			##


### PR DESCRIPTION
This alters year column behavior, to stop it from being force formatted into Y-m-d. On maria, the engine issues an "Out of range value for column '<column>' at row <row>" error, and casts the value to "0000"
