### PR TITLE
Reverts regular expression back to its original as it seems to work i…

### DIFF
--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -426,7 +426,7 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
 		if ( strpos($sql, '_ADODB_COUNT') !== FALSE ) {
 			$rewritesql = preg_replace('/^\s*?SELECT\s+_ADODB_COUNT(.*)_ADODB_COUNT\s/is','SELECT COUNT(*) ',$sql);
 		} else {
-			$rewritesql = preg_replace('/^\s*?SELECT\s.*?\s+(.*?)\s+FROM\s/is','SELECT COUNT(*) FROM ',$sql);
+			$rewritesql = preg_replace('/^\s*SELECT\s.*\s+FROM\s/Uis','SELECT COUNT(*) FROM ',$sql);
 		}
 		// fix by alexander zhukov, alex#unipack.ru, because count(*) and 'order by' fails
 		// with mssql, access and postgresql. Also a good speedup optimization - skips sorting!


### PR DESCRIPTION
REBASED from upstream master...

Reverts regular expression back to its original as it seems to work in more cases, and doesn't break simple cases. Since we support _ADODB_COUNT now anyways we should be able to handle any possible situation.

See Issue #236