### PR TITLE
Calling ADONewConnection with pdo_* causes a fatal error

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -4874,6 +4874,15 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 				$class = $db = 'postgres8';
 				break;
 
+			case 'pdo_mssql':
+			case 'pdo_mysql':
+			case 'pdo_oci':
+			case 'pdo_pgsql':
+			case 'pdo_sqlite':
+			case 'pdo_sqlsrv':
+				$class = $db = 'pdo';
+				break;
+
 			default:
 				$class = $db; break;
 		}

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -4874,17 +4874,13 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 				$class = $db = 'postgres8';
 				break;
 
-			case 'pdo_mssql':
-			case 'pdo_mysql':
-			case 'pdo_oci':
-			case 'pdo_pgsql':
-			case 'pdo_sqlite':
-			case 'pdo_sqlsrv':
-				$class = $db = 'pdo';
-				break;
-
 			default:
 				$class = $db; break;
+		}
+		
+		if (substr($db, 0, 4) === 'pdo_') {
+			ADOConnection::outp("Invalid database type $db");
+			return false;
 		}
 
 		$file = ADODB_DIR."/drivers/adodb-".$db.".inc.php";


### PR DESCRIPTION
If you pass `pdo_mssql`, `pdo_mysql`, etc to `ADONewConnection` there's a fatal error that occurs when `ADOLoadCode` includes the subclass file because `ADODB_pdo` is undefined.

Maybe those `pdo_*` strings aren't valid arguments to the function but the @ operator on the include that crashes makes it a bit of a nasty gotcha.