### PR TITLE
PDO: let driver handle SelectDB() and SQLDate() calls

### DIFF
--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -192,6 +192,7 @@ class ADODB_pdo extends ADOConnection {
 
 			$this->_driver->_connectionID = $this->_connectionID;
 			$this->_UpdatePDO();
+			$this->_driver->database = $this->database;
 			return true;
 		}
 		$this->_driver = new ADODB_pdo_base();
@@ -260,6 +261,16 @@ class ADODB_pdo extends ADOConnection {
 	function OffsetDate($dayFraction,$date=false)
 	{
 		return $this->_driver->OffsetDate($dayFraction,$date);
+	}
+
+	function SelectDB($dbName)
+	{
+		return $this->_driver->SelectDB($dbName);
+	}
+
+	function SQLDate($fmt, $col=false)
+	{
+		return $this->_driver->SQLDate($fmt, $col);
 	}
 
 	function ErrorMsg()


### PR DESCRIPTION
Calls to ADODB_pdo::SelectDB and ADODB_SQLDate should be passed through to the underlying $_driver object.

If the $database property of the underlying $_driver object isn't initialized correctly the 1st call to MetaColumns using "schemaName.tableName" as an argument may alter the connection's currently selected database

Related to #40