### PR TITLE
Support for T-SQL styled wrapping column names in square brackets

### DIFF
--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -861,6 +861,8 @@ static $cacheCols;
 			$bad = false;
 			if ((strpos($upperfname,' ') !== false) || ($ADODB_QUOTE_FIELDNAMES)) {
 				switch ($ADODB_QUOTE_FIELDNAMES) {
+				case 'BRACKETS':
+					$fnameq = $zthis->leftBracket.$upperfname.$zthis->rightBracket;break;
 				case 'LOWER':
 					$fnameq = $zthis->nameQuote.strtolower($field->name).$zthis->nameQuote;break;
 				case 'NATIVE':

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -691,6 +691,8 @@ function _adodb_getupdatesql(&$zthis,&$rs, $arrFields,$forceUpdate=false,$magicq
 
 					if ((strpos($upperfname,' ') !== false) || ($ADODB_QUOTE_FIELDNAMES)) {
 						switch ($ADODB_QUOTE_FIELDNAMES) {
+						case 'BRACKETS':
+							$fnameq = $zthis->leftBracket.$upperfname.$zthis->rightBracket;break;
 						case 'LOWER':
 							$fnameq = $zthis->nameQuote.strtolower($field->name).$zthis->nameQuote;break;
 						case 'NATIVE':

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -452,6 +452,8 @@ if (!defined('_ADODB_LAYER')) {
 	var $false = '0';			/// string that represents FALSE for a database
 	var $replaceQuote = "\\'";	/// string to use to replace quotes
 	var $nameQuote = '"';		/// string to use to quote identifiers and names
+	var $leftBracket = '[';		/// left square bracked for t-sql styled column names
+	var $rightBracket = ']';	/// right square bracked for t-sql styled column names
 	var $charSet=false;			/// character set to use - only for interbase, postgres and oci8
 	var $metaDatabasesSQL = '';
 	var $metaTablesSQL = '';


### PR DESCRIPTION
Microsoft wraps column names in square brackets in their t-sql statements, which is not really obligatory but it is necessary when columns have names same as reserved keywords (e.g. 'BEGIN' or 'CURRENT').

While it is still possible to manually wrap these column names with square brackets and use them in Execute() statement, the AutoExecute() will ignore these columns and may cause bad data or sql errors.

i can provide you some example code for better explanation and reproducing this problem, if you need.
