### PR TITLE
Eliminate notice that occurs when any ADO_pdo subclass calls Execute()

### DIFF
--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -454,7 +454,9 @@ class ADODB_pdo extends ADOConnection {
 		#adodb_backtrace();
 		#var_dump($this->_bindInputArray);
 		if ($stmt) {
-			$this->_driver->debug = $this->debug;
+			if (isset($this->_driver)) {
+				$this->_driver->debug = $this->debug;
+			}
 			if ($inputarr) {
 				$ok = $stmt->execute($inputarr);
 			}


### PR DESCRIPTION
Call chain is:
1. ADOConnection::Execute()
2. ADOConnection::_Execute()
3. ADO_pdo::_query()

Since $this is an ADO_pdo subclass rather than an ADO_pdo and $_driver isn't actually an inherited property of the parent class, $this->_driver doesn't exist.