### PR TITLE
MySQL MetaColumns() behavior.

### DIFF
--- a/drivers/adodb-mysql.inc.php
+++ b/drivers/adodb-mysql.inc.php
@@ -496,19 +496,16 @@ class ADODB_mysql extends ADOConnection {
 	{
 		$this->_findschema($table,$schema);
 		if ($schema) {
-			$dbName = $this->database;
-			$this->SelectDB($schema);
+			$meta = str_replace('FROM `%s`', 'FROM `'.$schema.'`.`%s`', $this->metaColumnsSQL);
+		} else {
+			$meta = $this->metaColumnsSQL;
 		}
 		global $ADODB_FETCH_MODE;
 		$save = $ADODB_FETCH_MODE;
 		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
 
 		if ($this->fetchMode !== false) $savem = $this->SetFetchMode(false);
-		$rs = $this->Execute(sprintf($this->metaColumnsSQL,$table));
-
-		if ($schema) {
-			$this->SelectDB($dbName);
-		}
+		$rs = $this->Execute(sprintf($meta,$table));
 
 		if (isset($savem)) $this->SetFetchMode($savem);
 		$ADODB_FETCH_MODE = $save;

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -665,12 +665,19 @@ class ADODB_mysqli extends ADOConnection {
 		if (!$this->metaColumnsSQL)
 			return $false;
 
+		$this->_findschema($table,$schema);
+		if ($schema) {
+			$meta = str_replace('FROM `%s`', 'FROM `'.$schema.'`.`%s`', $this->metaColumnsSQL);
+		} else {
+			$meta = $this->metaColumnsSQL;
+		}
+
 		global $ADODB_FETCH_MODE;
 		$save = $ADODB_FETCH_MODE;
 		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
 		if ($this->fetchMode !== false)
 			$savem = $this->SetFetchMode(false);
-		$rs = $this->Execute(sprintf($this->metaColumnsSQL,$table));
+		$rs = $this->Execute(sprintf($meta,$table));
 		if (isset($savem)) $this->SetFetchMode($savem);
 		$ADODB_FETCH_MODE = $save;
 		if (!is_object($rs))

--- a/drivers/adodb-pdo_mysql.inc.php
+++ b/drivers/adodb-pdo_mysql.inc.php
@@ -100,8 +100,9 @@ class ADODB_pdo_mysql extends ADODB_pdo {
 	{
 		$this->_findschema($table, $schema);
 		if ($schema) {
-			$dbName = $this->database;
-			$this->SelectDB($schema);
+			$meta = str_replace('FROM `%s`', 'FROM `'.$schema.'`.`%s`', $this->metaColumnsSQL);
+		} else {
+			$meta = $this->metaColumnsSQL;
 		}
 		global $ADODB_FETCH_MODE;
 		$save = $ADODB_FETCH_MODE;
@@ -110,11 +111,7 @@ class ADODB_pdo_mysql extends ADODB_pdo {
 		if ($this->fetchMode !== false) {
 			$savem = $this->SetFetchMode(false);
 		}
-		$rs = $this->Execute(sprintf($this->metaColumnsSQL, $table));
-
-		if ($schema) {
-			$this->SelectDB($dbName);
-		}
+		$rs = $this->Execute(sprintf($meta, $table));
 
 		if (isset($savem)) {
 			$this->SetFetchMode($savem);


### PR DESCRIPTION
Currently the mysql and pdo_mysql drivers will check for a schema in the argument and if found will change the connection's selected schema, get the table information, and change the connection's selected schema back. I think that's unnecessarily complicated. Manipulating the state of the connection creates the possibility of giving it back to the caller in a different state and it's not strictly necessary anyway. This change also detects a schema in the argument but modifies the metaColumnsSQL string rather than modifying the connection.

I added the same behavior for mysqli because it seemed strange for only 2 out of 3 options to support "schema.table" syntax.