### PR TITLE
oci8po: prevent segfault on php7

### DIFF
--- a/drivers/adodb-oci8po.inc.php
+++ b/drivers/adodb-oci8po.inc.php
@@ -133,8 +133,10 @@ class ADORecordset_oci8po extends ADORecordset_oci8 {
 	// 10% speedup to move MoveNext to child class
 	function MoveNext()
 	{
-		if(@OCIfetchinto($this->_queryID,$this->fields,$this->fetchMode)) {
+		$ret = @oci_fetch_array($this->_queryID,$this->fetchMode);
+		if($ret !== false) {
 		global $ADODB_ANSI_PADDING_OFF;
+			$this->fields = $ret;
 			$this->_currentRow++;
 			$this->_updatefields();
 
@@ -164,10 +166,12 @@ class ADORecordset_oci8po extends ADORecordset_oci8 {
 				$arr = array();
 				return $arr;
 			}
-		if (!@OCIfetchinto($this->_queryID,$this->fields,$this->fetchMode)) {
+		$ret = @oci_fetch_array($this->_queryID,$this->fetchMode);
+		if ($ret === false) {
 			$arr = array();
 			return $arr;
 		}
+		$this->fields = $ret;
 		$this->_updatefields();
 		$results = array();
 		$cnt = 0;
@@ -183,8 +187,9 @@ class ADORecordset_oci8po extends ADORecordset_oci8 {
 	{
 		global $ADODB_ANSI_PADDING_OFF;
 
-		$ret = @OCIfetchinto($this->_queryID,$this->fields,$this->fetchMode);
+		$ret = @oci_fetch_array($this->_queryID,$this->fetchMode);
 		if ($ret) {
+			$this->fields = $ret;
 			$this->_updatefields();
 
 			if (!empty($ADODB_ANSI_PADDING_OFF)) {
@@ -193,7 +198,7 @@ class ADORecordset_oci8po extends ADORecordset_oci8 {
 				}
 			}
 		}
-		return $ret;
+		return $ret !== false;
 	}
 
 }


### PR DESCRIPTION
The OCIFetchinto function is causing segfaults on php7 - probably because the fields array
is not initialised or it is optimised out. This fixes just changes to use the safer function
oci_fetch_array instead.

The attached script will trigger the segfault.

[test.php.txt](https://github.com/ADOdb/ADOdb/files/358900/test.php.txt)
