### PR TITLE
FIX: ADODB_pdo_mysql::MetaTables fails w/ default args

### DIFF
--- a/drivers/adodb-pdo_mysql.inc.php
+++ b/drivers/adodb-pdo_mysql.inc.php
@@ -70,7 +70,7 @@ class ADODB_pdo_mysql extends ADODB_pdo {
 	{
 		$save = $this->metaTablesSQL;
 		if ($showSchema && is_string($showSchema)) {
-			$this->metaTablesSQL .= " from $showSchema";
+			$this->metaTablesSQL .= $this->qstr($showSchema);
 		} else {
 			$this->metaTablesSQL .= "schema()";
 		}

--- a/drivers/adodb-pdo_mysql.inc.php
+++ b/drivers/adodb-pdo_mysql.inc.php
@@ -71,6 +71,8 @@ class ADODB_pdo_mysql extends ADODB_pdo {
 		$save = $this->metaTablesSQL;
 		if ($showSchema && is_string($showSchema)) {
 			$this->metaTablesSQL .= " from $showSchema";
+		} else {
+			$this->metaTablesSQL .= "schema()";
 		}
 
 		if ($mask) {


### PR DESCRIPTION
The generated query is broken with the default method arguments. It issues this query:
```sql
SELECT
            TABLE_NAME,
            CASE WHEN TABLE_TYPE = 'VIEW' THEN 'V' ELSE 'T' END
        FROM INFORMATION_SCHEMA.TABLES
        WHERE TABLE_SCHEMA=
```
which of course fails.

The fix is taken from `ADODB_mysqli::MetaTables`.