### PR TITLE
ADORecordSet contructor takes only one parameter

### DIFF
--- a/drivers/adodb-ado.inc.php
+++ b/drivers/adodb-ado.inc.php
@@ -350,7 +350,7 @@ class ADORecordSet_ado extends ADORecordSet {
 			$mode = $ADODB_FETCH_MODE;
 		}
 		$this->fetchMode = $mode;
-		return parent::__construct($id,$mode);
+		return parent::__construct($id);
 	}
 
 


### PR DESCRIPTION
ADORecordSet class contructor only takes $queryID parameter, but ADORecordSet_ado class sends two paremeter on constructor.
