### PR TITLE
CIDR type omitted from postgres MetaType

### DIFF
--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -1063,6 +1063,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 				case 'NAME':
 				case 'BPCHAR':
 				case '_VARCHAR':
+				case 'CIDR':
 				case 'INET':
 				case 'MACADDR':
 					if ($len <= $this->blobSize) return 'C';


### PR DESCRIPTION
Hello!

The CIDR type was omitted from the postgres MetaType translation, thus it gets picked up as ADODB_DEFAULT_METATYPE and casted to a float. later on down the road if using GetUpdateSQL().  This places it back in its proper place.