### PR TITLE
Inconsistent variable binding in SelectLimit and oci8po driver

### DIFF
--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -755,10 +755,11 @@ END;
 
 			if (is_array($inputarr)) {
 				foreach($inputarr as $k => $v) {
+					$i=0;
 					if ($this->databaseType == 'oci8po') {
-						$bv_name = ":".array_search($k, array_keys($inputarr));
+						$bv_name = ":".$i++;
 					} else {
-						$bv_name = ":$k";
+						$bv_name = ":".$k;
 					}
 					if (is_array($v)) {
 						// suggested by g.giunta@libero.

--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -755,13 +755,18 @@ END;
 
 			if (is_array($inputarr)) {
 				foreach($inputarr as $k => $v) {
+					if ($this->databaseType == 'oci8po') {
+						$bv_name = ":".array_search($k, array_keys($inputarr));
+					} else {
+						$bv_name = ":$k";
+					}
 					if (is_array($v)) {
 						// suggested by g.giunta@libero.
 						if (sizeof($v) == 2) {
-							oci_bind_by_name($stmt,":$k",$inputarr[$k][0],$v[1]);
+							oci_bind_by_name($stmt,$bv_name,$inputarr[$k][0],$v[1]);
 						}
 						else {
-							oci_bind_by_name($stmt,":$k",$inputarr[$k][0],$v[1],$v[2]);
+							oci_bind_by_name($stmt,$bv_name,$inputarr[$k][0],$v[1],$v[2]);
 						}
 					} else {
 						$len = -1;
@@ -771,7 +776,7 @@ END;
 						if (isset($bindarr)) {	// is prepared sql, so no need to oci_bind_by_name again
 							$bindarr[$k] = $v;
 						} else { 				// dynamic sql, so rebind every time
-							oci_bind_by_name($stmt,":$k",$inputarr[$k],$len);
+							oci_bind_by_name($stmt,$bv_name,$inputarr[$k],$len);
 						}
 					}
 				}


### PR DESCRIPTION
Method SelectLimit in oci8po driver handles bind variables inconsistenly:

for $nrow < 1000: $inputarr can be indexed or associative array
for $nrow >= 1000: $inputarr must be indexed array

I tracked it down to line 777 of adodb-oci8.inc.php:

```php
oci_bind_by_name($stmt,":$k",$inputarr[$k],$len);
```

In this case ":$k" does not work with ? placeholder.

Proposed solution: for oci8po driver, always use index key values.