### PR TITLE
mssql: fix drop/alter column with existing default constraint

### DIFF
--- a/datadict/datadict-mssqlnative.inc.php
+++ b/datadict/datadict-mssqlnative.inc.php
@@ -148,19 +148,63 @@ class ADODB2_mssqlnative extends ADODB_DataDict {
 		return $sql;
 	}
 
-	/*
-	function AlterColumnSQL($tabname, $flds, $tableflds='', $tableoptions='')
+	function DefaultConstraintname($tabname, $colname)
+	{
+		$constraintname = false;
+		$rs = $this->connection->Execute( "select name from sys.default_constraints WHERE object_name(parent_object_id) = '" . $tabname ."' AND col_name(parent_object_id, parent_column_id) = '" . $colname . "'");
+		if ( is_object($rs) ) {
+			$row = $rs->FetchRow();
+			$constraintname = $row['name'];
+		}
+		return $constraintname;
+	}
+  
+	function AlterColumnSQL($tabname, $flds, $tableflds='',$tableoptions='')
 	{
 		$tabname = $this->TableName ($tabname);
 		$sql = array();
-		list($lines,$pkey) = $this->_GenFields($flds);
-		foreach($lines as $v) {
-			$sql[] = "ALTER TABLE $tabname $this->alterCol $v";
-		}
 
+		list($lines,$pkey,$idxs) = $this->_GenFields($flds);
+		$alter = 'ALTER TABLE ' . $tabname . $this->alterCol . ' ';
+		foreach($lines as $v) {
+			$not_null = false;
+			if ($not_null = preg_match('/NOT NULL/i',$v)) {
+				$v = preg_replace('/NOT NULL/i','',$v);
+			}         
+			if (preg_match('/^([^ ]+) .*DEFAULT (\'[^\']+\'|\"[^\"]+\"|[^ ]+)/',$v,$matches)) {
+				list(,$colname,$default) = $matches;
+				$v = preg_replace('/^' . preg_quote($colname) . '\s/', '', $v);
+				$t = trim(str_replace('DEFAULT '.$default,'',$v));
+				if ( $constraintname = $this->DefaultConstraintname($tabname,$colname) ) {
+					$sql[] = 'ALTER TABLE '.$tabname.' DROP CONSTRAINT '. $constraintname;
+				}
+				if ($not_null) {
+					$sql[] = $alter . $colname . ' ' . $t  . ' NOT NULL';
+				} else {
+					$sql[] = $alter . $colname . ' ' . $t ;
+				}
+				$sql[] = 'ALTER TABLE '.$tabname.' ADD CONSTRAINT DF__'. $tabname . '__'.  $colname.  '__' . dechex(rand()) .' DEFAULT ' . $default . ' FOR ' . $colname;
+			} else {
+				$colname = strtok($v," ");
+				if ( $constraintname = $this->DefaultConstraintname($tabname,$colname) ) {
+					$sql[] = 'ALTER TABLE '.$tabname.' DROP CONSTRAINT '. $constraintname;
+				}
+				if ($not_null) {
+					$sql[] = $alter . $v  . ' NOT NULL';
+				} else {
+					$sql[] = $alter . $v;
+				}
+			}
+		}
+		if (is_array($idxs)) {
+			foreach($idxs as $idx => $idxdef) {
+				$sql_idxs = $this->CreateIndexSql($idx, $tabname, $idxdef['cols'], $idxdef['opts']);
+				$sql = array_merge($sql, $sql_idxs);
+			}
+		}
 		return $sql;
 	}
-	*/
+
 
 	/**
 	 * Drop a column, syntax is ALTER TABLE table DROP COLUMN column,column
@@ -178,10 +222,12 @@ class ADODB2_mssqlnative extends ADODB_DataDict {
 		if (!is_array($flds))
 			$flds = explode(',',$flds);
 		$f = array();
-		$s = 'ALTER TABLE ' . $tabname . ' DROP COLUMN ';
+		$s = 'ALTER TABLE ' . $tabname;
 		foreach($flds as $v) {
-			//$f[] = "\n$this->dropCol ".$this->NameQuote($v);
-			$f[] = $this->NameQuote($v);
+			if ( $constraintname = $this->DefaultConstraintname($tabname,$v) ) {
+				$sql[] = 'ALTER TABLE '.$tabname.' DROP CONSTRAINT '. $constraintname;
+			}
+			$f[] = ' DROP COLUMN '.$this->NameQuote($v);
 		}
 		$s .= implode(', ',$f);
 		$sql[] = $s;


### PR DESCRIPTION
With MSSQL it is not possible to drop or alter a column with an existing default constraint. This constraint has to be removed before the drop or alter takes place.

This patch removes an existing default constraint before the drop/alter column is
filed and in case of alter creates a new one. after that, if a 'DEFAULT' is given.

Fixes #290