### PR TITLE
ensure `$nrows` and `$offset` parameters of `SelectLimit` are integers

### DIFF
--- a/drivers/adodb-pdo_mysql.inc.php
+++ b/drivers/adodb-pdo_mysql.inc.php
@@ -192,6 +192,8 @@ class ADODB_pdo_mysql extends ADODB_pdo {
 	// parameters use PostgreSQL convention, not MySQL
 	function SelectLimit($sql, $nrows=-1, $offset=-1, $inputarr=false, $secs=0)
 	{
+		$nrows = (int) $nrows;
+		$offset = (int) $offset;		
 		$offsetStr =($offset>=0) ? "$offset," : '';
 		// jason judge, see http://phplens.com/lens/lensforum/msgs.php?id=9220
 		if ($nrows < 0) {


### PR DESCRIPTION
as is done (at least for `$nrows`) in the `SelectLimit` method of `Adodb/adodb.inc.php`.

lowers the risk of SQL injection.