### PR TITLE
Allow output handler to be callable (on object)

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -628,8 +628,7 @@ if (!defined('_ADODB_LAYER')) {
 			$fn($msg,$newline);
 			return;
 		} else if (isset($ADODB_OUTP)) {
-			$fn = $ADODB_OUTP;
-			$fn($msg,$newline);
+			call_user_func($ADODB_OUTP,$msg,$newline);
 			return;
 		}
 


### PR DESCRIPTION
Currently when defining `$ADODB_OUTP` you can set a custom output
function. However i want to use an object method as an output handler.

So now `$ADODB_OUTP` is fed to call_user_func so we can set:
`$ADODB_OUTP=array($object,'output_method');`

This should be fully backwards compatible.