### PR TITLE
Fix: pdo sqlsrv change transaction isolation level error

### DIFF
--- a/drivers/adodb-pdo_sqlsrv.inc.php
+++ b/drivers/adodb-pdo_sqlsrv.inc.php
@@ -166,4 +166,15 @@ class ADORecordSet_array_pdo_sqlsrv extends ADORecordSet_array_pdo
 		$fieldObjects[$fieldOffset] = $o;
 		return $o;
 	}
+	
+	function SetTransactionMode( $transaction_mode )
+	{
+		$this->_transmode  = $transaction_mode;
+		if (empty($transaction_mode)) {
+			$this->_connectionID->query('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+			return;
+		}
+		if (!stristr($transaction_mode,'isolation')) $transaction_mode = 'ISOLATION LEVEL '.$transaction_mode;
+		$this->_connectionID->query("SET TRANSACTION ".$transaction_mode);
+	}
 }


### PR DESCRIPTION
Fixes PDO Error: The transaction isolation level cannot be changed for this driver