### PR TITLE
Added support for connecting using windows authentication

### DIFF
--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -475,9 +475,12 @@ class ADODB_mssqlnative extends ADOConnection {
 
 		$connectionInfo 			= $this->connectionInfo;
 		$connectionInfo["Database"]	= $argDatabasename;
-		$connectionInfo["UID"]		= $argUsername;
-		$connectionInfo["PWD"]		= $argPassword;
-
+		if (!((is_null($argUsername) || (is_string($argUsername) && strlen($argUsername) === 0)) &&
+			   is_null($argPassword) || (is_string($argPassword) && strlen($argPassword) === 0))) {
+			$connectionInfo["UID"]=$argUsername;
+			$connectionInfo["PWD"]=$argPassword;
+		}
+		
 		/*
 		* Now merge in the passed connection parameters setting
 		*/


### PR DESCRIPTION
To connect to the SQL Server using windows authentication the username and password arguments have to be omitted. So i just check if these are null or have a length of 0. If both the username and password are not set I do not add them to the connection info. This way the native SQL driver connects using windows authentication.