### PR TITLE
MSSQL requires table alias in _adodb_getcount() query

### DIFF
--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -416,7 +416,10 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
 			} else
 				$rewritesql = "SELECT COUNT(*) FROM (".$rewritesql.")";
 
-		} else if (strncmp($zthis->databaseType,'postgres',8) == 0 || strncmp($zthis->databaseType,'mysql',5) == 0)  {
+		} else if (strncmp($zthis->databaseType,'postgres',8) == 0
+			|| strncmp($zthis->databaseType,'mysql',5) == 0
+			|| strncmp($zthis->databaseType,'mssql',5) == 0
+		) {
 			$rewritesql = "SELECT COUNT(*) FROM ($rewritesql) _ADODB_ALIAS_";
 		} else {
 			$rewritesql = "SELECT COUNT(*) FROM ($rewritesql)";


### PR DESCRIPTION
Currently the _ADODB_ALIAS_ is only used for postgres and mysql, but it's also necessary for mssql, otherwise the query assigned to $rewritesql on line 422 fails and produces the following warning:
PHP Warning (2):  mssql_query(): message: Incorrect syntax near ')'. (severity 15) in /usr/share/php/adodb/drivers/adodb-mssql.inc.php on line 832