### PR TITLE
Use include_once instead of include

### DIFF
--- a/adodb-active-record.inc.php
+++ b/adodb-active-record.inc.php
@@ -522,7 +522,7 @@ class ADODB_Active_Record {
 			$activetab->_created = time();
 			$s = serialize($activetab);
 			if (!function_exists('adodb_write_file')) {
-				include(ADODB_DIR.'/adodb-csvlib.inc.php');
+				include_once(ADODB_DIR.'/adodb-csvlib.inc.php');
 			}
 			adodb_write_file($fname,$s);
 		}

--- a/adodb-active-recordx.inc.php
+++ b/adodb-active-recordx.inc.php
@@ -551,7 +551,7 @@ class ADODB_Active_Record {
 			$activetab->_created = time();
 			$s = serialize($activetab);
 			if (!function_exists('adodb_write_file')) {
-				include(ADODB_DIR.'/adodb-csvlib.inc.php');
+				include_once(ADODB_DIR.'/adodb-csvlib.inc.php');
 			}
 			adodb_write_file($fname,$s);
 		}
@@ -1300,7 +1300,7 @@ function adodb_GetActiveRecordsClass(&$db, $class, $tableObj,$whereOrderBy,$bind
 
 
 		if (!isset($_ADODB_ACTIVE_DBS)) {
-			include(ADODB_DIR.'/adodb-active-record.inc.php');
+			include_once(ADODB_DIR.'/adodb-active-record.inc.php');
 		}
 		if (!class_exists($class)) {
 			$db->outp_throw("Unknown class $class in GetActiveRecordsClass()",'GetActiveRecordsClass');

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1271,7 +1271,7 @@ if (!defined('_ADODB_LAYER')) {
 		if ($this->debug) {
 			global $ADODB_INCLUDED_LIB;
 			if (empty($ADODB_INCLUDED_LIB)) {
-				include(ADODB_DIR.'/adodb-lib.inc.php');
+				include_once(ADODB_DIR.'/adodb-lib.inc.php');
 			}
 			$this->_queryID = _adodb_debug_execute($this, $sql,$inputarr);
 		} else {
@@ -1976,7 +1976,7 @@ if (!defined('_ADODB_LAYER')) {
 	function Replace($table, $fieldArray, $keyCol, $autoQuote=false, $has_autoinc=false) {
 		global $ADODB_INCLUDED_LIB;
 		if (empty($ADODB_INCLUDED_LIB)) {
-			include(ADODB_DIR.'/adodb-lib.inc.php');
+			include_once(ADODB_DIR.'/adodb-lib.inc.php');
 		}
 
 		return _adodb_replace($this, $table, $fieldArray, $keyCol, $autoQuote, $has_autoinc);
@@ -2265,7 +2265,7 @@ if (!defined('_ADODB_LAYER')) {
 		// ********************************************************
 
 		if (empty($ADODB_INCLUDED_LIB)) {
-			include(ADODB_DIR.'/adodb-lib.inc.php');
+			include_once(ADODB_DIR.'/adodb-lib.inc.php');
 		}
 		return _adodb_getupdatesql($this,$rs,$arrFields,$forceUpdate,$magicq,$force);
 	}
@@ -2285,7 +2285,7 @@ if (!defined('_ADODB_LAYER')) {
 			$force = $ADODB_FORCE_TYPE;
 		}
 		if (empty($ADODB_INCLUDED_LIB)) {
-			include(ADODB_DIR.'/adodb-lib.inc.php');
+			include_once(ADODB_DIR.'/adodb-lib.inc.php');
 		}
 		return _adodb_getinsertsql($this,$rs,$arrFields,$magicq,$force);
 	}
@@ -3083,7 +3083,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	function PageExecute($sql, $nrows, $page, $inputarr=false, $secs2cache=0) {
 		global $ADODB_INCLUDED_LIB;
 		if (empty($ADODB_INCLUDED_LIB)) {
-			include(ADODB_DIR.'/adodb-lib.inc.php');
+			include_once(ADODB_DIR.'/adodb-lib.inc.php');
 		}
 		if ($this->pageExecuteCountRows) {
 			$rs = _adodb_pageexecute_all_rows($this, $sql, $nrows, $page, $inputarr, $secs2cache);
@@ -3332,7 +3332,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	// DATE AND TIME FUNCTIONS
 	//==============================================================================================
 	if (!defined('ADODB_DATE_VERSION')) {
-		include(ADODB_DIR.'/adodb-time.inc.php');
+		include_once(ADODB_DIR.'/adodb-time.inc.php');
 	}
 
 	//==============================================================================================
@@ -3496,7 +3496,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	{
 		global $ADODB_INCLUDED_LIB;
 		if (empty($ADODB_INCLUDED_LIB)) {
-			include(ADODB_DIR.'/adodb-lib.inc.php');
+			include_once(ADODB_DIR.'/adodb-lib.inc.php');
 		}
 		return _adodb_getmenu($this, $name,$defstr,$blank1stItem,$multiple,
 			$size, $selectAttr,$compareFields0);
@@ -3524,7 +3524,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	{
 		global $ADODB_INCLUDED_LIB;
 		if (empty($ADODB_INCLUDED_LIB)) {
-			include(ADODB_DIR.'/adodb-lib.inc.php');
+			include_once(ADODB_DIR.'/adodb-lib.inc.php');
 		}
 		return _adodb_getmenu_gp($this, $name,$defstr,$blank1stItem,$multiple,
 			$size, $selectAttr,false);
@@ -4569,7 +4569,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 			global $ADODB_INCLUDED_LIB;
 
 			if (empty($ADODB_INCLUDED_LIB)) {
-				include(ADODB_DIR.'/adodb-lib.inc.php');
+				include_once(ADODB_DIR.'/adodb-lib.inc.php');
 			}
 			$hdr = true;
 
@@ -5147,7 +5147,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	function adodb_backtrace($printOrArr=true,$levels=9999,$ishtml=null) {
 		global $ADODB_INCLUDED_LIB;
 		if (empty($ADODB_INCLUDED_LIB)) {
-			include(ADODB_DIR.'/adodb-lib.inc.php');
+			include_once(ADODB_DIR.'/adodb-lib.inc.php');
 		}
 		return _adodb_backtrace($printOrArr,$levels,0,$ishtml);
 	}

--- a/drivers/adodb-access.inc.php
+++ b/drivers/adodb-access.inc.php
@@ -15,7 +15,7 @@
 if (!defined('_ADODB_ODBC_LAYER')) {
 	if (!defined('ADODB_DIR')) die();
 
-	include(ADODB_DIR."/drivers/adodb-odbc.inc.php");
+	include_once(ADODB_DIR."/drivers/adodb-odbc.inc.php");
 }
 
 if (!defined('_ADODB_ACCESS')) {

--- a/drivers/adodb-ado_access.inc.php
+++ b/drivers/adodb-ado_access.inc.php
@@ -17,8 +17,8 @@ Set tabs to 4 for best viewing.
 if (!defined('ADODB_DIR')) die();
 
 if (!defined('_ADODB_ADO_LAYER')) {
-	if (PHP_VERSION >= 5) include(ADODB_DIR."/drivers/adodb-ado5.inc.php");
-	else include(ADODB_DIR."/drivers/adodb-ado.inc.php");
+	if (PHP_VERSION >= 5) include_once(ADODB_DIR."/drivers/adodb-ado5.inc.php");
+	else include_once(ADODB_DIR."/drivers/adodb-ado.inc.php");
 }
 
 class  ADODB_ado_access extends ADODB_ado {

--- a/drivers/adodb-ado_mssql.inc.php
+++ b/drivers/adodb-ado_mssql.inc.php
@@ -21,8 +21,8 @@ Set tabs to 4 for best viewing.
 if (!defined('ADODB_DIR')) die();
 
 if (!defined('_ADODB_ADO_LAYER')) {
-	if (PHP_VERSION >= 5) include(ADODB_DIR."/drivers/adodb-ado5.inc.php");
-	else include(ADODB_DIR."/drivers/adodb-ado.inc.php");
+	if (PHP_VERSION >= 5) include_once(ADODB_DIR."/drivers/adodb-ado5.inc.php");
+	else include_once(ADODB_DIR."/drivers/adodb-ado.inc.php");
 }
 
 

--- a/drivers/adodb-db2oci.inc.php
+++ b/drivers/adodb-db2oci.inc.php
@@ -15,7 +15,7 @@ Set tabs to 4 for best viewing.
 
 // security - hide paths
 if (!defined('ADODB_DIR')) die();
-include(ADODB_DIR."/drivers/adodb-db2.inc.php");
+include_once(ADODB_DIR."/drivers/adodb-db2.inc.php");
 
 
 if (!defined('ADODB_DB2OCI')){

--- a/drivers/adodb-db2ora.inc.php
+++ b/drivers/adodb-db2ora.inc.php
@@ -15,7 +15,7 @@ Set tabs to 4 for best viewing.
 
 // security - hide paths
 if (!defined('ADODB_DIR')) die();
-include(ADODB_DIR."/drivers/adodb-db2.inc.php");
+include_once(ADODB_DIR."/drivers/adodb-db2.inc.php");
 
 
 if (!defined('ADODB_DB2OCI')){

--- a/drivers/adodb-odbc_db2.inc.php
+++ b/drivers/adodb-odbc_db2.inc.php
@@ -92,7 +92,7 @@ to DB2 full rights to the DB2 SQLLIB directory, and place the user in the DBUSER
 if (!defined('ADODB_DIR')) die();
 
 if (!defined('_ADODB_ODBC_LAYER')) {
-	include(ADODB_DIR."/drivers/adodb-odbc.inc.php");
+	include_once(ADODB_DIR."/drivers/adodb-odbc.inc.php");
 }
 if (!defined('ADODB_ODBC_DB2')){
 define('ADODB_ODBC_DB2',1);

--- a/drivers/adodb-odbc_mssql.inc.php
+++ b/drivers/adodb-odbc_mssql.inc.php
@@ -18,7 +18,7 @@ Set tabs to 4 for best viewing.
 if (!defined('ADODB_DIR')) die();
 
 if (!defined('_ADODB_ODBC_LAYER')) {
-	include(ADODB_DIR."/drivers/adodb-odbc.inc.php");
+	include_once(ADODB_DIR."/drivers/adodb-odbc.inc.php");
 }
 
 

--- a/drivers/adodb-odbc_oracle.inc.php
+++ b/drivers/adodb-odbc_oracle.inc.php
@@ -16,7 +16,7 @@ Set tabs to 4 for best viewing.
 if (!defined('ADODB_DIR')) die();
 
 if (!defined('_ADODB_ODBC_LAYER')) {
-	include(ADODB_DIR."/drivers/adodb-odbc.inc.php");
+	include_once(ADODB_DIR."/drivers/adodb-odbc.inc.php");
 }
 
 

--- a/drivers/adodb-odbtp_unicode.inc.php
+++ b/drivers/adodb-odbtp_unicode.inc.php
@@ -26,7 +26,7 @@ if (!defined('ADODB_DIR')) die();
 */
 
 if (!defined('_ADODB_ODBTP_LAYER')) {
-	include(ADODB_DIR."/drivers/adodb-odbtp.inc.php");
+	include_once(ADODB_DIR."/drivers/adodb-odbtp.inc.php");
 }
 
 class ADODB_odbtp_unicode extends ADODB_odbtp {

--- a/drivers/adodb-proxy.inc.php
+++ b/drivers/adodb-proxy.inc.php
@@ -16,7 +16,7 @@ if (!defined('ADODB_DIR')) die();
 
 if (! defined("_ADODB_PROXY_LAYER")) {
 	define("_ADODB_PROXY_LAYER", 1 );
-	include(ADODB_DIR."/drivers/adodb-csv.inc.php");
+	include_once(ADODB_DIR."/drivers/adodb-csv.inc.php");
 
 class ADODB_proxy extends ADODB_csv {
 	var $databaseType = 'proxy';

--- a/drivers/adodb-sapdb.inc.php
+++ b/drivers/adodb-sapdb.inc.php
@@ -18,7 +18,7 @@ Set tabs to 4 for best viewing.
 if (!defined('ADODB_DIR')) die();
 
 if (!defined('_ADODB_ODBC_LAYER')) {
-	include(ADODB_DIR."/drivers/adodb-odbc.inc.php");
+	include_once(ADODB_DIR."/drivers/adodb-odbc.inc.php");
 }
 if (!defined('ADODB_SAPDB')){
 define('ADODB_SAPDB',1);

--- a/drivers/adodb-sqlanywhere.inc.php
+++ b/drivers/adodb-sqlanywhere.inc.php
@@ -47,7 +47,7 @@ Set tabs to 4 for best viewing.
 if (!defined('ADODB_DIR')) die();
 
 if (!defined('_ADODB_ODBC_LAYER')) {
- include(ADODB_DIR."/drivers/adodb-odbc.inc.php");
+ include_once(ADODB_DIR."/drivers/adodb-odbc.inc.php");
 }
 
 if (!defined('ADODB_SYBASE_SQLANYWHERE')){

--- a/drivers/adodb-vfp.inc.php
+++ b/drivers/adodb-vfp.inc.php
@@ -17,7 +17,7 @@ Set tabs to 4 for best viewing.
 if (!defined('ADODB_DIR')) die();
 
 if (!defined('_ADODB_ODBC_LAYER')) {
-	include(ADODB_DIR."/drivers/adodb-odbc.inc.php");
+	include_once(ADODB_DIR."/drivers/adodb-odbc.inc.php");
 }
 if (!defined('ADODB_VFP')){
 define('ADODB_VFP',1);


### PR DESCRIPTION
Most of the includes in adodb.inc.php are done with include_once but
in a couple locations its still done with include.

This is the case for adodb-lib.inc.php which is conditionally included
based on a global var. I ran into problems with running adodb in debug
mode while running phpuni tests. Phpunit will reset the global vars
and thus break the include mechanism. This is a problem of phpunit
and can be worked around. However it would make adodb more robust
to just use include_once everywhere. It will remove the dependency on
the $ADODB_INCLUDED_LIB global var.

I also replaced one include statement of adodb-time.inc.php so
include_once is used everywhere.