### PR TITLE
Bugfix in the oci8po Driver

### DIFF
--- a/drivers/adodb-oci8po.inc.php
+++ b/drivers/adodb-oci8po.inc.php
@@ -83,7 +83,7 @@ class ADODB_oci8po extends ADODB_oci8 {
 			} else {
 				// Need to identify if the ? is inside a quoted string, and if
 				// so not use it as a bind variable
-				preg_match_all('/".*\??"|\'.*\?.*?\'/', $sql, $matches);
+				preg_match_all('/".*?"|\'.*?\'/', $sql, $matches);
 				foreach($matches[0] as $qmMatch){
 					$qmReplace = str_replace('?', '-QUESTIONMARK-', $qmMatch);
 					$sql = str_replace($qmMatch, $qmReplace, $sql);


### PR DESCRIPTION
The Regular Expression you use in the "_query" function, located
in the adodb-oci8po driver, doesn't serve its purpose.

The comment right before the code line tells that you
"_[n]eed to identify if the **?** is inside a quoted string, and if so not use it as a bind variable_"
but the current expression does the following:

Example String:
**SELECT something FROM my_table WHERE name = 'randomValue' AND id = ? AND lastname IN('smith','miller')**;

If you dare to use an example string where you have any ' after a ? you get the following return string:
**'randomValue' AND id = ? AND lastname IN('** although
the right quoted strings are **randomValue**, **"smith**, **miller**.
So we have way to many characters in the return string and the first **'** after the initial **'** is ignored, what leads to **?** not being used as a bind variable, although it was intended to be used as one.


I suggest to change the Regular Expression to filter every quoted string (weather it has an ? or not)
and then mask the ? within the quoted strings, so they don't get binded
(this last part is already implemented, but the given "quoted" strings are wrong in some cases as shown in my example).

My solution leads to more string matches beeing processed and searched,
and therefore it is (depending on the amount of quoted strings you provide in your query)
more performance heavy, so I wouldn't mind if anybody suggests a better way to solve the problem.