### PR TITLE
LAST_INSERT_ID() is not accessible after the transaction

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1394,7 +1394,7 @@ if (!defined('_ADODB_LAYER')) {
 	 * @return  the last inserted ID. Not all databases support this.
 	 */
 	function Insert_ID($table='',$column='') {
-		if ($this->_logsql && $this->lastInsID) {
+		if ($this->_logsql || $this->lastInsID) {
 			return $this->lastInsID;
 		}
 		if ($this->hasInsertID) {


### PR DESCRIPTION
Insert_ID returns 0 when executed after a transaction has been committed, fixed with calling _insertid() before transaction get's committed and saving to parents $lastInsID