### PR TITLE
Warning. sybase_connect

### DIFF
--- a/drivers/adodb-sybase.inc.php
+++ b/drivers/adodb-sybase.inc.php
@@ -150,9 +150,9 @@ class ADODB_sybase extends ADOConnection {
 		}
 
 		if ($this->charSet) {
-			$this->_connectionID = sybase_pconnect($argHostname,$argUsername,$argPassword, $this->charSet);
+			$this->_connectionID = @sybase_pconnect($argHostname,$argUsername,$argPassword, $this->charSet);
 		} else {
-			$this->_connectionID = sybase_pconnect($argHostname,$argUsername,$argPassword);
+			$this->_connectionID = @sybase_pconnect($argHostname,$argUsername,$argPassword);
 		}
 
 		if ($this->_connectionID === false) return false;


### PR DESCRIPTION
Sybase Connect Server message, Changed database context.
Although it is only a warning, it generates an error in the log with connections to external Sybase databases.
The error message is generated in moodle login, with system debugging enabled.