### PR TITLE
soft year validation in adodb_validdate

### DIFF
--- a/adodb-time.inc.php
+++ b/adodb-time.inc.php
@@ -816,7 +816,7 @@ global $_month_table_normal,$_month_table_leaf;
 
 	if ($marr[$m] < $d) return false;
 
-	if ($y < 1000 && $y > 3000) return false;
+	if ($y < 1000 || $y > 3000) return false;
 
 	return true;
 }


### PR DESCRIPTION
fixes #375 
given year can only be less than 3000 or greater than 1000