### PR TITLE
Let go of a potential reference to a db resource (leading to an OBDC dll crash).

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -2470,6 +2470,7 @@ if (!defined('_ADODB_LAYER')) {
 	 */
 	function Close() {
 		$rez = $this->_close();
+		$this->_queryID = false;
 		$this->_connectionID = false;
 		return $rez;
 	}


### PR DESCRIPTION
We had a problem in our app using the pdo_sqlsrv driver with PHP 7
that manifested itself by a ODBC32.dll crash at the end of some PHP requests
(see issue: https://github.com/Microsoft/msphpsql/issues/434).

It seems the dll tried to free a statement after the connection had been disconnected.

We looked at our code and the ADOdb code to see if a reference to a statement
could imply that it would be garbage-collected after the PDO disconnection.

We found that `ADODB_pdo#_query` returns a statement to `ADOConnection#_Execute`
which stores it in its `_queryID` property and never empties it explicitly.

Setting it to `false` in `ADOConnection#Close` seems to fix the problem in our app.

What do you think of this change?