### PR TITLE
Session pdo support

### DIFF
--- a/session/adodb-session2.php
+++ b/session/adodb-session2.php
@@ -564,28 +564,44 @@ class ADODB_Session {
 #		assert('$database');
 #		assert('$driver');
 #		assert('$host');
-
-		$conn = ADONewConnection($driver);
-
-		if ($debug) {
-			$conn->debug = true;
-			ADOConnection::outp( " driver=$driver user=$user db=$database ");
-		}
-
-		if (empty($conn->_connectionID)) { // not dsn
+		if (strpos($driver, 'pdo_') === 0){
+			$conn = ADONewConnection('pdo');
+			$driver = str_replace('pdo_', '', $driver)
+			$dsn=$driver+':'+'hostname='+$host+';database='+$database+';'
+			$db->connect($dsn,$user,$password);
 			if ($persist) {
 				switch($persist) {
 				default:
-				case 'P': $ok = $conn->PConnect($host, $user, $password, $database); break;
-				case 'C': $ok = $conn->Connect($host, $user, $password, $database); break;
-				case 'N': $ok = $conn->NConnect($host, $user, $password, $database); break;
+				case 'P': $ok = $conn->PConnect($dsn,$user,$password); break;
+				case 'C': $ok = $conn->Connect($dsn,$user,$password); break;
+				case 'N': $ok = $conn->NConnect($dsn,$user,$password); break;
 				}
 			} else {
-				$ok = $conn->Connect($host, $user, $password, $database);
+				$ok = $conn->Connect($dsn,$user,$password);
 			}
-		} else {
-			$ok = true; // $conn->_connectionID is set after call to ADONewConnection
+		}else{
+			$conn = ADONewConnection($driver);
+			if ($debug) {
+				$conn->debug = true;
+				ADOConnection::outp( " driver=$driver user=$user db=$database ");
+			}
+
+			if (empty($conn->_connectionID)) { // not dsn
+				if ($persist) {
+					switch($persist) {
+					default:
+					case 'P': $ok = $conn->PConnect($host, $user, $password, $database); break;
+					case 'C': $ok = $conn->Connect($host, $user, $password, $database); break;
+					case 'N': $ok = $conn->NConnect($host, $user, $password, $database); break;
+					}
+				} else {
+					$ok = $conn->Connect($host, $user, $password, $database);
+				}
+			} else {
+				$ok = true; // $conn->_connectionID is set after call to ADONewConnection
+			}
 		}
+
 
 		if ($ok) $GLOBALS['ADODB_SESS_CONN'] = $conn;
 		else

--- a/session/adodb-session2.php
+++ b/session/adodb-session2.php
@@ -566,9 +566,8 @@ class ADODB_Session {
 #		assert('$host');
 		if (strpos($driver, 'pdo_') === 0){
 			$conn = ADONewConnection('pdo');
-			$driver = str_replace('pdo_', '', $driver)
-			$dsn=$driver+':'+'hostname='+$host+';database='+$database+';'
-			$db->connect($dsn,$user,$password);
+			$driver = str_replace('pdo_', '', $driver);
+			$dsn = $driver.':'.'hostname='.$host.';dbname='.$database.';';
 			if ($persist) {
 				switch($persist) {
 				default:
@@ -580,7 +579,7 @@ class ADODB_Session {
 				$ok = $conn->Connect($dsn,$user,$password);
 			}
 		}else{
-			$conn = ADONewConnection($driver);
+			$conn = ADONewConnection($driverÏ);
 			if ($debug) {
 				$conn->debug = true;
 				ADOConnection::outp( " driver=$driver user=$user db=$database ");
@@ -823,7 +822,7 @@ class ADODB_Session {
 		//assert('$table');
 
 		$qkey = $conn->quote($key);
-		$binary = $conn->dataProvider === 'mysql' ? '/*! BINARY */' : '';
+		$binary = $conn->dataProvider === 'mysql' || $conn->dataProvider === 'pdo' ? '/*! BINARY */' : '';
 
 		if ($expire_notify) {
 			reset($expire_notify);

--- a/session/adodb-session2.php
+++ b/session/adodb-session2.php
@@ -579,7 +579,7 @@ class ADODB_Session {
 				$ok = $conn->Connect($dsn,$user,$password);
 			}
 		}else{
-			$conn = ADONewConnection($driverÏ);
+			$conn = ADONewConnection($driver);
 			if ($debug) {
 				$conn->debug = true;
 				ADOConnection::outp( " driver=$driver user=$user db=$database ");


### PR DESCRIPTION
Add support for using PDO for ADODB Sessions.

To use just specify driver as 'pdo_mysql' in your ADOdb_Session::config call.  

eg.
ADOdb_Session::config('pdo_mysql', $host, $user, $password, $database,$options=false);
