### PR TITLE
Remove statics from fetchField

### DIFF
--- a/drivers/adodb-pdo_sqlsrv.inc.php
+++ b/drivers/adodb-pdo_sqlsrv.inc.php
@@ -62,15 +62,9 @@ class ADORecordSet_pdo_sqlsrv extends ADORecordSet_pdo
 	public function fetchField($fieldOffset = 0)
 	{
 
-		static $fieldObjects = array();
 		// Default behavior allows passing in of -1 offset, which crashes the method
 		if ($fieldOffset == -1) {
 			$fieldOffset++;
-		}
-
-		if (isset($fieldObjects[$fieldOffset])) {
-			// Look for cached field offset
-			return $fieldObjects[$fieldOffset];
 		}
 
 		$o = new ADOFieldObject();
@@ -102,8 +96,6 @@ class ADORecordSet_pdo_sqlsrv extends ADORecordSet_pdo
 				break;
 		}
 
-		// Add to the cache
-		$fieldObjects[$fieldOffset] = $o;
 		return $o;
 	}
 }
@@ -122,15 +114,9 @@ class ADORecordSet_array_pdo_sqlsrv extends ADORecordSet_array_pdo
 	 */
 	public function fetchField($fieldOffset = 0)
 	{
-		static $fieldObjects = array();
 		// Default behavior allows passing in of -1 offset, which crashes the method
 		if ($fieldOffset == -1) {
 			$fieldOffset++;
-		}
-
-		if (isset($fieldObjects[$fieldOffset])) {
-			// Look for cached field offset
-			return $fieldObjects[$fieldOffset];
 		}
 
 		$o = new ADOFieldObject();
@@ -162,8 +148,6 @@ class ADORecordSet_array_pdo_sqlsrv extends ADORecordSet_array_pdo
 				break;
 		}
 
-		// Add to the cache
-		$fieldObjects[$fieldOffset] = $o;
 		return $o;
 	}
 	


### PR DESCRIPTION
In the pdo_sqlsrv driver, static locals were used to cache field names.
Unfortunately, this means that if the results for multiple queries
were mapped, the field names for the first query were used instead of
updated field names for the subsequent queries.