### PR TITLE
Concat method missing for odbc_mssql driver

### DIFF
--- a/drivers/adodb-odbc_mssql.inc.php
+++ b/drivers/adodb-odbc_mssql.inc.php
@@ -393,6 +393,30 @@ order by constraint_name, referenced_table_name, keyno";
 	{
 		return ADODB_STRINGMAX_NOLIMIT;
 	}
+	
+	// returns concatenated string
+	// MSSQL requires integers to be cast as strings
+	// automatically cast every datatype to VARCHAR(255)
+	// @author David Rogers (introspectshun)
+	function Concat()
+	{
+		$s = "";
+		$arr = func_get_args();
+
+		// Split single record on commas, if possible
+		if (sizeof($arr) == 1) {
+			foreach ($arr as $arg) {
+				$args = explode(',', $arg);
+			}
+			$arr = $args;
+		}
+
+		array_walk($arr, create_function('&$v', '$v = "CAST(" . $v . " AS VARCHAR(255))";'));
+		$s = implode('+',$arr);
+		if (sizeof($arr) > 0) return "$s";
+
+		return '';
+	}
 
 }
 


### PR DESCRIPTION
An error may occur in comparitions that needs casting.