### PR TITLE
PHP-X-version compat: Don't attempt to call `dl()` when the function is disabled

### DIFF
--- a/adodb-pear.inc.php
+++ b/adodb-pear.inc.php
@@ -358,7 +358,7 @@ class DB
 	 */
 	function assertExtension($name)
 	{
-		if (!extension_loaded($name)) {
+		if (function_exists('dl') && !extension_loaded($name)) {
 			$dlext = (strncmp(PHP_OS,'WIN',3) === 0) ? '.dll' : '.so';
 			@dl($name . $dlext);
 		}


### PR DESCRIPTION
The `dl()`has been removed/disabled in most SAPIs since PHP 5.3, so chances of it being available are rather slim.

> 7.0.0 	dl() is disabled in PHP-FPM.
> 5.3.9 	dl() is enabled in PHP-FPM, albeit discouraged.
> 5.3.0 	dl() is now disabled in some SAPIs due to stability issues. The only SAPIs that allow dl() are CLI and Embed. Use the Extension Loading Directives instead.

Ref: http://php.net/manual/en/function.dl.php#refsect1-function.dl-changelog