### PR TITLE
PHP-X-version compat: Don't bother with magic quotes when not available

### DIFF
--- a/adodb-xmlschema.inc.php
+++ b/adodb-xmlschema.inc.php
@@ -1305,8 +1305,9 @@ class adoSchema {
 	function __construct( $db ) {
 		// Initialize the environment
 		$this->mgq = get_magic_quotes_runtime();
-		ini_set("magic_quotes_runtime", 0);
-		#set_magic_quotes_runtime(0);
+		if ($this->mgq !== false) {
+			ini_set('magic_quotes_runtime', 0);
+		}
 
 		$this->db = $db;
 		$this->debug = $this->db->debug;
@@ -2195,8 +2196,9 @@ class adoSchema {
 	* @deprecated adoSchema now cleans up automatically.
 	*/
 	function Destroy() {
-		ini_set("magic_quotes_runtime", $this->mgq );
-		#set_magic_quotes_runtime( $this->mgq );
+		if ($this->mgq !== false) {
+			ini_set('magic_quotes_runtime', $this->mgq );
+		}
 	}
 }
 

--- a/adodb-xmlschema03.inc.php
+++ b/adodb-xmlschema03.inc.php
@@ -1409,8 +1409,9 @@ class adoSchema {
 	function __construct( $db ) {
 		// Initialize the environment
 		$this->mgq = get_magic_quotes_runtime();
-		#set_magic_quotes_runtime(0);
-		ini_set("magic_quotes_runtime", 0);
+		if ($this->mgq !== false) {
+			ini_set('magic_quotes_runtime', 0 );
+		}
 
 		$this->db = $db;
 		$this->debug = $this->db->debug;
@@ -2377,8 +2378,9 @@ class adoSchema {
 	* @deprecated adoSchema now cleans up automatically.
 	*/
 	function Destroy() {
-		ini_set("magic_quotes_runtime", $this->mgq );
-		#set_magic_quotes_runtime( $this->mgq );
+		if ($this->mgq !== false) {
+			ini_set('magic_quotes_runtime', $this->mgq );
+		}
 	}
 }
 


### PR DESCRIPTION
Magic quotes were removed from PHP in v5.4.0.

The return value of `get_magic_quotes_runtime()` will be `0` if `magic_quotes_runtime` is off, `1` otherwise.
And as of PHP 5.4.0, it will always returns `false`.

This minor change prevents trying to set the ini value when the ini directive is not available and cleans up some old/unused/commented out code.

Refs:
* http://php.net/manual/en/info.configuration.php#ini.magic-quotes-runtime
* http://php.net/manual/en/function.get-magic-quotes-runtime.php