### PR TITLE
PHP-X-version compat: Replace use of `each()` with foreach()

### DIFF
--- a/drivers/adodb-text.inc.php
+++ b/drivers/adodb-text.inc.php
@@ -255,8 +255,7 @@ class ADODB_text extends ADOConnection {
 					$projtypes = array($this->_types[$i]);
 					$projnames = array($n);
 
-					reset($where_arr);
-					while (list($k_a,$a) = each($where_arr)) {
+					foreach($where_arr as $k_a => $a ) {
 						if ($i == 0 && $this->_skiprow1) {
 							$projarray[] = array($n);
 							continue;


### PR DESCRIPTION
`each()` has been deprecated as of PHP 7.2.
The recommended replacement is using `foreach()`.

Looks like one instance was missed in the previous PR related to this. (#373) Fixed now.

Refs:
* http://php.net/manual/en/migration72.deprecated.php#migration72.deprecated.each-function
* http://php.net/manual/en/function.each.php
* http://php.net/manual/en/control-structures.foreach.php