### PR TITLE
PHP-X-version compat: Replace usages of deprecated `$php_errormsg`

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -3042,6 +3042,61 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		return $rs;
 	}
 
+	/**
+	 * Get the last error recorded by PHP and clear the message.
+	 *
+	 * By clearing the message, it becomes possible to detect whether a new error
+	 * has occurred, even when it is the same error as before being repeated.
+	 *
+	 * @return array|null Array if an error has previously occurred. Null otherwise.
+	 */
+	protected function resetLastError() {
+		$error = error_get_last();
+
+		if (is_array($error)) {
+			$error['message'] = '';
+		}
+
+		return $error;
+	}
+
+	/**
+	 * Compare a previously stored error message with the last error recorded by PHP
+	 * to determine whether a new error has occured.
+	 *
+	 * @param array|null $old Optional. Previously stored return value of error_get_last().
+	 *
+	 * @return string The error message if a new error has occured
+	 *                or an empty string if no (new) errors have occured..
+	 */
+	protected function getChangedErrorMsg($old = null) {
+		$new = error_get_last();
+
+		if (is_null($new)) {
+			// No error has occured yet at all.
+			return '';
+		}
+
+		if (is_null($old)) {
+			// First error recorded.
+			return $new['message'];
+		}
+
+		$changed = false;
+		foreach($new as $key => $value) {
+			if ($new[$key] !== $old[$key]) {
+				$changed = true;
+				break;
+			}
+		}
+
+		if ($changed === true) {
+			return $new['message'];
+		}
+
+		return '';
+	}
+
 } // end class ADOConnection
 
 

--- a/drivers/adodb-ads.inc.php
+++ b/drivers/adodb-ads.inc.php
@@ -80,11 +80,10 @@ class ADODB_ads extends ADOConnection {
     if ($this->debug && $argDatabasename && $this->databaseType != 'vfp') {
       ADOConnection::outp("For Advantage Connect(), $argDatabasename is not used. Place dsn in 1st parameter.");
     }
-    error_clear_last();
+    $last_php_error = $this->resetLastError();
     if ($this->curmode === false) $this->_connectionID = ads_connect($argDSN,$argUsername,$argPassword);
     else $this->_connectionID = ads_connect($argDSN,$argUsername,$argPassword,$this->curmode);
-    $err = error_get_last();
-    $this->_errorMsg = $err ? $err['message'] : '';
+    $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
     if (isset($this->connectStmt)) $this->Execute($this->connectStmt);
 
     return $this->_connectionID != false;
@@ -93,10 +92,10 @@ class ADODB_ads extends ADOConnection {
   // returns true or false
   function _pconnect($argDSN, $argUsername, $argPassword, $argDatabasename)
   {
-
     if (!function_exists('ads_connect')) return null;
 
-    error_clear_last();
+    $last_php_error = $this->resetLastError();
+    $this->_errorMsg = '';
     if ($this->debug && $argDatabasename) {
             ADOConnection::outp("For PConnect(), $argDatabasename is not used. Place dsn in 1st parameter.");
     }
@@ -104,8 +103,7 @@ class ADODB_ads extends ADOConnection {
     if ($this->curmode === false) $this->_connectionID = ads_connect($argDSN,$argUsername,$argPassword);
     else $this->_connectionID = ads_pconnect($argDSN,$argUsername,$argPassword,$this->curmode);
 
-    $err = error_get_last();
-    $this->_errorMsg = $err ? $err['message'] : '';
+    $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
     if ($this->_connectionID && $this->autoRollback) @ads_rollback($this->_connectionID);
     if (isset($this->connectStmt)) $this->Execute($this->connectStmt);
 
@@ -517,8 +515,8 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
   /* returns queryID or false */
   function _query($sql,$inputarr=false)
   {
-    error_clear_last();
-    $this->_error = '';
+    $last_php_error = $this->resetLastError();
+    $this->_errorMsg = '';
 
                 if ($inputarr) {
       if (is_array($sql)) {
@@ -527,8 +525,7 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
         $stmtid = ads_prepare($this->_connectionID,$sql);
 
         if ($stmtid == false) {
-          $err = error_get_last();
-          $this->_errorMsg = $err ? $err['message'] : '';
+          $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
           return false;
         }
       }
@@ -579,16 +576,14 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
         $this->_errorMsg = '';
         $this->_errorCode = 0;
       } else {
-          $err = error_get_last();
-          $this->_errorMsg = $err ? $err['message'] : '';
+          $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
       }
     } else {
       if ($this->_haserrorfunctions) {
         $this->_errorMsg = ads_errormsg();
         $this->_errorCode = ads_error();
       } else {
-          $err = error_get_last();
-          $this->_errorMsg = $err ? $err['message'] : '';
+          $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
       }
     }
 
@@ -607,11 +602,11 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
    */
   function UpdateBlob($table,$column,$val,$where,$blobtype='BLOB')
   {
+                $last_php_error = $this->resetLastError();
                 $sql = "UPDATE $table SET $column=? WHERE $where";
                 $stmtid = ads_prepare($this->_connectionID,$sql);
                 if ($stmtid == false){
-                  $err = error_get_last();
-                  $this->_errorMsg = $err ? $err['message'] : '';
+                  $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
                   return false;
           }
                 if (! ads_execute($stmtid,array($val),array(SQL_BINARY) )){

--- a/drivers/adodb-db2.inc.php
+++ b/drivers/adodb-db2.inc.php
@@ -108,6 +108,8 @@ class ADODB_db2 extends ADOConnection {
 		// Replaces the odbc_binmode() call that was in Execute()
 		ini_set('ibm_db2.binmode', $this->binmode);
 
+		$this->_errorMsg = '';
+
 		if ($argDatabasename && empty($argDSN)) {
 
 			if (stripos($argDatabasename,'UID=') && stripos($argDatabasename,'PWD=')) $this->_connectionID = db2_pconnect($argDatabasename,null,null);
@@ -619,7 +621,7 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/db2/htm/db2
 	/* returns queryID or false */
 	function _query($sql,$inputarr=false)
 	{
-		error_clear_last();
+		$last_php_error = $this->resetLastError();
 		$this->_errorMsg = '';
 
 		if ($inputarr) {
@@ -629,8 +631,7 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/db2/htm/db2
 				$stmtid = db2_prepare($this->_connectionID,$sql);
 
 				if ($stmtid == false) {
-					$err = error_get_last();
-					$this->_errorMsg = $err ? $err['message'] : '';
+					$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 					return false;
 				}
 			}
@@ -668,16 +669,14 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/db2/htm/db2
 				$this->_errorMsg = '';
 				$this->_errorCode = 0;
 			} else {
-				$err = error_get_last();
-				$this->_errorMsg = $err ? $err['message'] : '';
+				$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 			}
 		} else {
 			if ($this->_haserrorfunctions) {
 				$this->_errorMsg = db2_stmt_errormsg();
 				$this->_errorCode = db2_stmt_error();
 			} else {
-				$err = error_get_last();
-				$this->_errorMsg = $err ? $err['message'] : '';
+				$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 			}
 		}
 		return $stmtid;

--- a/drivers/adodb-odbc.inc.php
+++ b/drivers/adodb-odbc.inc.php
@@ -59,11 +59,10 @@ class ADODB_odbc extends ADOConnection {
 			$argDSN .= 'Database='.$argDatabasename;
 		}
 
-		error_clear_last();
+		$last_php_error = $this->resetLastError();
 		if ($this->curmode === false) $this->_connectionID = odbc_connect($argDSN,$argUsername,$argPassword);
 		else $this->_connectionID = odbc_connect($argDSN,$argUsername,$argPassword,$this->curmode);
-		$err = error_get_last();
-		$this->_errorMsg = $err ? $err['message'] : '';
+		$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 		if (isset($this->connectStmt)) $this->Execute($this->connectStmt);
 
 		return $this->_connectionID != false;
@@ -72,10 +71,10 @@ class ADODB_odbc extends ADOConnection {
 	// returns true or false
 	function _pconnect($argDSN, $argUsername, $argPassword, $argDatabasename)
 	{
-
 		if (!function_exists('odbc_connect')) return null;
 
-		error_clear_last();
+		$last_php_error = $this->resetLastError();
+		$this->_errorMsg = '';
 		if ($this->debug && $argDatabasename) {
 			ADOConnection::outp("For odbc PConnect(), $argDatabasename is not used. Place dsn in 1st parameter.");
 		}
@@ -83,8 +82,7 @@ class ADODB_odbc extends ADOConnection {
 		if ($this->curmode === false) $this->_connectionID = odbc_connect($argDSN,$argUsername,$argPassword);
 		else $this->_connectionID = odbc_pconnect($argDSN,$argUsername,$argPassword,$this->curmode);
 
-		$err = error_get_last();
-		$this->_errorMsg = $err ? $err['message'] : '';
+		$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 		if ($this->_connectionID && $this->autoRollback) @odbc_rollback($this->_connectionID);
 		if (isset($this->connectStmt)) $this->Execute($this->connectStmt);
 
@@ -501,8 +499,8 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
 	/* returns queryID or false */
 	function _query($sql,$inputarr=false)
 	{
-		error_clear_last();
-		$this->_error = '';
+		$last_php_error = $this->resetLastError();
+		$this->_errorMsg = '';
 
 		if ($inputarr) {
 			if (is_array($sql)) {
@@ -511,8 +509,7 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
 				$stmtid = odbc_prepare($this->_connectionID,$sql);
 
 				if ($stmtid == false) {
-					$err = error_get_last();
-					$this->_errorMsg = $err ? $err['message'] : '';
+					$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 					return false;
 				}
 			}
@@ -554,16 +551,14 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
 				$this->_errorMsg = '';
 				$this->_errorCode = 0;
 			} else {
-				$err = error_get_last();
-				$this->_errorMsg = $err ? $err['message'] : '';
+				$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 			}
 		} else {
 			if ($this->_haserrorfunctions) {
 				$this->_errorMsg = odbc_errormsg();
 				$this->_errorCode = odbc_error();
 			} else {
-				$err = error_get_last();
-				$this->_errorMsg = $err ? $err['message'] : '';
+				$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 			}
 		}
 		return $stmtid;

--- a/drivers/adodb-odbc_oracle.inc.php
+++ b/drivers/adodb-odbc_oracle.inc.php
@@ -76,10 +76,9 @@ class  ADODB_odbc_oracle extends ADODB_odbc {
 	// returns true or false
 	function _connect($argDSN, $argUsername, $argPassword, $argDatabasename)
 	{
-		error_clear_last();
+		$last_php_error = $this->resetLastError();
 		$this->_connectionID = odbc_connect($argDSN,$argUsername,$argPassword,SQL_CUR_USE_ODBC );
-		$err = error_get_last();
-		$this->_errorMsg = $err ? $err['message'] : '';
+		$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 
 		$this->Execute("ALTER SESSION SET NLS_DATE_FORMAT='YYYY-MM-DD HH24:MI:SS'");
 		//if ($this->_connectionID) odbc_autocommit($this->_connectionID,true);
@@ -88,10 +87,9 @@ class  ADODB_odbc_oracle extends ADODB_odbc {
 	// returns true or false
 	function _pconnect($argDSN, $argUsername, $argPassword, $argDatabasename)
 	{
-		error_clear_last();
+		$last_php_error = $this->resetLastError();
 		$this->_connectionID = odbc_pconnect($argDSN,$argUsername,$argPassword,SQL_CUR_USE_ODBC );
-		$err = error_get_last();
-		$this->_errorMsg = $err ? $err['message'] : '';
+		$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 
 		$this->Execute("ALTER SESSION SET NLS_DATE_FORMAT='YYYY-MM-DD HH24:MI:SS'");
 		//if ($this->_connectionID) odbc_autocommit($this->_connectionID,true);

--- a/drivers/adodb-odbtp.inc.php
+++ b/drivers/adodb-odbtp.inc.php
@@ -609,7 +609,7 @@ class ADODB_odbtp extends ADOConnection{
 
 	function _query($sql,$inputarr=false)
 	{
-		error_clear_last();
+		$last_php_error = $this->resetLastError();
 		$this->_errorMsg = false;
 		$this->_errorCode = false;
 
@@ -619,8 +619,7 @@ class ADODB_odbtp extends ADOConnection{
 			} else {
 				$stmtid = @odbtp_prepare($sql,$this->_connectionID);
 				if ($stmtid == false) {
-					$err = error_get_last();
-					$this->_errorMsg = $err ? $err['message'] : '';
+					$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
 					return false;
 				}
 			}

--- a/drivers/adodb-sybase.inc.php
+++ b/drivers/adodb-sybase.inc.php
@@ -118,8 +118,7 @@ class ADODB_sybase extends ADOConnection {
 		if (function_exists('sybase_get_last_message'))
 			$this->_errorMsg = sybase_get_last_message();
 		else {
-			$err = error_get_last();
-			$this->_errorMsg = $err ? $err['message'] : 'SYBASE error messages not supported on this platform';
+			$this->_errorMsg = 'SYBASE error messages not supported on this platform';
 		}
 
 		return $this->_errorMsg;


### PR DESCRIPTION
The PHP native `$php_errormsg` variable has been deprecated as of PHP 7.2.
The recommended replacement is `error_get_last()`.

A number of the driver classes used  `$php_errormsg` to track if a DB action caused an error.
As the `error_get_last()` function returns an array and comparing the message therefore is slightly more involved, two new methods have been introduced into the abstract parent class `ADOConnection` to handle the message comparison.

The `resetLastError()` method retrieves the initial (old) error message and resets it to enable checking whether a new error has occurred, even when the new error is the same as the previous one.
The new `getChangedErrorMsg()` method compares the old error message with the current one to determine whether a new message has occurred, and if so, returns the message.

Refs:
* http://php.net/manual/en/migration72.deprecated.php#migration72.deprecated.track_errors-and-php_errormsg
* http://php.net/manual/en/reserved.variables.phperrormsg.php
* http://php.net/manual/en/function.error-get-last.php

Additional notes:
* In the `ADODB_ads::UpdateBlob()` method, the original (old) message was not being retrieved which could result in an unrelated error being recorded. This has been fixed.
* In the `ADODB_db2::_connect()` and `ADODB_db2::_pconnect()` methods, the `$php_errormsg` was being reset, but subsequently not checked for changes, so as the variable in effect was not being used, I've removed the related code.
* In the `ADODB_sybase::ErrorMsg()` method, the `$php_errormsg` was being checked, but no functions which could potential cause errors are being called. As `$php_errormsg` is only available in the scope an error occurred in, this meant that `$php_errormsg` would always be empty, so I've removed the related code.

Fixes #405