### PR TITLE
SSL for mysqli connections

### DIFF
--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -59,11 +59,11 @@ class ADODB_mysqli extends ADOConnection {
 	var $optionFlags = array(array(MYSQLI_READ_DEFAULT_GROUP,0));
 	var $arrayClass = 'ADORecordSet_array_mysqli';
 	var $multiQuery = false;
-	var $ssl_key = false;
-	var $ssl_cer = false;
-	var $ssl_ca = false;
-	var $ssl_capath = false;
-	var $ssl_cipher = false;
+	var $ssl_key = null;
+	var $ssl_cer = null;
+	var $ssl_ca = null;
+	var $ssl_capath = null;
+	var $ssl_cipher = null;
 
 	/*
 	* Tells the insert_id method how to obtain the last value, depending on whether

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -126,7 +126,7 @@ class ADODB_mysqli extends ADOConnection {
 		if ($persist && PHP_VERSION > 5.2 && strncmp($argHostname,'p:',2) != 0) $argHostname = 'p:'.$argHostname;
 
 		// SSL Connections for MySQLI
-		if ($this->ssl_key || $this->ssl_cer || $this->ssl_ca || $this->ssl_ccapath || $this->ca_cipher) {
+		if ($this->ssl_key || $this->ssl_cer || $this->ssl_ca || $this->ssl_capath || $this->ssl_cipher) {
 			mysqli_ssl_set($this->_connectionID, $this->ssl_key, $this->ssl_cer, $this->ssl_ca, $this->ssl_capath, $this->ssl_cipher);
 		}
 

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -59,6 +59,11 @@ class ADODB_mysqli extends ADOConnection {
 	var $optionFlags = array(array(MYSQLI_READ_DEFAULT_GROUP,0));
 	var $arrayClass = 'ADORecordSet_array_mysqli';
 	var $multiQuery = false;
+	var $ssl_key = false;
+	var $ssl_cer = false;
+	var $ssl_ca = false;
+	var $ssl_capath = false;
+	var $ssl_cipher = false;
 
 	/*
 	* Tells the insert_id method how to obtain the last value, depending on whether
@@ -119,6 +124,11 @@ class ADODB_mysqli extends ADOConnection {
 
 		//http ://php.net/manual/en/mysqli.persistconns.php
 		if ($persist && PHP_VERSION > 5.2 && strncmp($argHostname,'p:',2) != 0) $argHostname = 'p:'.$argHostname;
+
+		// SSL Connections for MySQLI
+		if ($this->ssl_key || $this->ssl_cer || $this->ssl_ca || $this->ssl_ccapath || $this->ca_cipher) {
+            mysqli_ssl_set($this->_connectionID, $this->ssl_key, $this->ssl_cer, $this->ssl_ca, $this->ssl_capath, $this->ssl_cipher);
+        }
 
 		#if (!empty($this->port)) $argHostname .= ":".$this->port;
 		$ok = @mysqli_real_connect($this->_connectionID,

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -127,8 +127,8 @@ class ADODB_mysqli extends ADOConnection {
 
 		// SSL Connections for MySQLI
 		if ($this->ssl_key || $this->ssl_cer || $this->ssl_ca || $this->ssl_ccapath || $this->ca_cipher) {
-            mysqli_ssl_set($this->_connectionID, $this->ssl_key, $this->ssl_cer, $this->ssl_ca, $this->ssl_capath, $this->ssl_cipher);
-        }
+			mysqli_ssl_set($this->_connectionID, $this->ssl_key, $this->ssl_cer, $this->ssl_ca, $this->ssl_capath, $this->ssl_cipher);
+		}
 
 		#if (!empty($this->port)) $argHostname .= ":".$this->port;
 		$ok = @mysqli_real_connect($this->_connectionID,


### PR DESCRIPTION
MySQL has the ability to have secured connections via a certificate/ key/ etc. This is quite simple in Azure to configure. However ADODB's connect function inits-and-connects in a single function call, and the SSL trigger needs to happen between the two if it's not part of the my.cnf. I'd like to propose an extension to the adodb-mysqli.inc.php