### PR TITLE
making the count wrapper sqlsrver compliant

### DIFF
--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -418,6 +418,7 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
 
         } else if (strncmp($zthis->databaseType,'postgres',8) == 0
             || strncmp($zthis->databaseType,'mysql',5) == 0
+	    || strncmp($zthis->databaseType,'mssql',5) == 0
             || strncmp($zthis->dsnType,'sqlsrv',5) == 0
         ){
 		    $rewritesql = "SELECT COUNT(*) FROM ($rewritesql) _ADODB_ALIAS_";

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -416,15 +416,13 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
 			} else
 				$rewritesql = "SELECT COUNT(*) FROM (".$rewritesql.")";
 
-		} else if (strncmp($zthis->databaseType,'postgres',8) == 0
-			|| strncmp($zthis->databaseType,'mysql',5) == 0
-			|| strncmp($zthis->databaseType,'mssql',5) == 0
-		) {
-			$rewritesql = "SELECT COUNT(*) FROM ($rewritesql) _ADODB_ALIAS_";
-		} else {
-		    // SqlSrver compliant - Larry Adams on 6/7/2018
-			$rewritesql = "SELECT COUNT(*) FROM ($rewritesql) _ADODB_ALIAS_";
-		}
+        } else if (strncmp($zthis->databaseType,'postgres',8) == 0
+            || strncmp($zthis->databaseType,'mysql',5) == 0
+            || strncmp($zthis->databaseType,'mssql',5) == 0)  {
+            $rewritesql = "SELECT COUNT(*) FROM ($rewritesql) _ADODB_ALIAS_";
+        } else {
+            $rewritesql = "SELECT COUNT(*) FROM ($rewritesql)";
+        }
 	} else {
 		// now replace SELECT ... FROM with SELECT COUNT(*) FROM
 		if ( strpos($sql, '_ADODB_COUNT') !== FALSE ) {

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -422,7 +422,8 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
 		) {
 			$rewritesql = "SELECT COUNT(*) FROM ($rewritesql) _ADODB_ALIAS_";
 		} else {
-			$rewritesql = "SELECT COUNT(*) FROM ($rewritesql)";
+		    // SqlSrver compliant - Larry Adams on 6/7/2018
+			$rewritesql = "SELECT COUNT(*) FROM ($rewritesql) _ADODB_ALIAS_";
 		}
 	} else {
 		// now replace SELECT ... FROM with SELECT COUNT(*) FROM

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -418,8 +418,9 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
 
         } else if (strncmp($zthis->databaseType,'postgres',8) == 0
             || strncmp($zthis->databaseType,'mysql',5) == 0
-            || strncmp($zthis->databaseType,'mssql',5) == 0)  {
-            $rewritesql = "SELECT COUNT(*) FROM ($rewritesql) _ADODB_ALIAS_";
+            || strncmp($zthis->dsnType,'sqlsrv',5) == 0
+        ){
+		    $rewritesql = "SELECT COUNT(*) FROM ($rewritesql) _ADODB_ALIAS_";
         } else {
             $rewritesql = "SELECT COUNT(*) FROM ($rewritesql)";
         }

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -420,6 +420,7 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
             || strncmp($zthis->databaseType,'mysql',5) == 0
 	    || strncmp($zthis->databaseType,'mssql',5) == 0
             || strncmp($zthis->dsnType,'sqlsrv',5) == 0
+            || strncmp($zthis->dsnType,'mssql',5) == 0
         ){
 		    $rewritesql = "SELECT COUNT(*) FROM ($rewritesql) _ADODB_ALIAS_";
         } else {


### PR DESCRIPTION
We use ADODB for Oracle and MSSQL, but the count wrapping is broken for MSSQL. MSSQL requires an alias at the end and the way we fall into the conditional flow is forcing us to hack the adodb-lib.inc.php.

I hope this is good enough to get it into master, but if not please advise me on how I can accommodate the project needs.


Thank you,

-Larry Adams