### PR TITLE
remove error suppression from mssqlnative (and more?) driver

### DIFF
--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -1136,10 +1136,7 @@ class ADORecordset_mssqlnative extends ADORecordSet {
 	function _fetch($ignore_fields=false)
 	{
 		if ($this->fetchMode & ADODB_FETCH_ASSOC) {
-			if ($this->fetchMode & ADODB_FETCH_NUM)
-				$this->fields = sqlsrv_fetch_array($this->_queryID,SQLSRV_FETCH_BOTH);
-			else
-				$this->fields = sqlsrv_fetch_array($this->_queryID,SQLSRV_FETCH_ASSOC);
+			$this->fields = sqlsrv_fetch_array($this->_queryID,$this->fetchMode & ADODB_FETCH_NUM ? SQLSRV_FETCH_BOTH : SQLSRV_FETCH_ASSOC);
 
 			if (is_array($this->fields))
 			{


### PR DESCRIPTION
The `@`-Operator suppresses ALL errors and resulted in a script that exited/aborted without any error message because the error (memory limit exceeded) happened within the `sqlsrv_fetch_array` function.

I did not get the advantage of suppressing the errors and I currently don't see any problems within our application with this.

Any information why the error suppression was introduced?
If you wish, I could remove the error suppression from all other drivers as well.