### PR TITLE
Sqlsrv identity

### DIFF
--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -642,7 +642,7 @@ class ADODB_mssqlnative extends ADOConnection {
 		if(!$rez)
 			$rez = false;
 		if ($insert)
-			$this->_lastInsertResult = $res;
+			$this->_lastInsertResult = $rez;
 
 		return $rez;
 	}


### PR DESCRIPTION
With the `sqlsrv` module the `identitySQL` method (`SELECT SCOPE_IDENTITY()`) frequently (always?) returns `NULL`. The existing implementation [accounts for this](https://github.com/ADOdb/ADOdb/blob/master/drivers/adodb-mssqlnative.inc.php#L614-L619) in `_query()` by checking the statement for an `INSERT` and appending the `identitySQL` query to it. Running an `INSERT` query actually returns the result of `SELECT SCOPE_IDENTITY()` instead of the result of the `INSERT` query.

This works fine if you're aware of this behavior and examine the result of the insert query instead of calling `Insert_ID()`, but it means code that works with the `mssql` driver won't work the same way with the `mssqlnative` driver and I think that's fixable.

Keeping a copy of the last insert result from `_query()` and using it in `_insertid()` when available makes the change in query behavior transparent to the caller and they can continue using `Insert_ID()`.