### PR TITLE
Simplified pdo_mysql driver SelectLimit Method

### DIFF
--- a/drivers/adodb-pdo_mysql.inc.php
+++ b/drivers/adodb-pdo_mysql.inc.php
@@ -204,15 +204,15 @@ class ADODB_pdo_mysql extends ADODB_pdo {
 		$nrows = (int) $nrows;
 		$offset = (int) $offset;		
 		$offsetStr =($offset>=0) ? "$offset," : '';
-		// jason judge, see http://phplens.com/lens/lensforum/msgs.php?id=9220
-		if ($nrows < 0) {
-			$nrows = '18446744073709551615';
+
+		if ($nrows > 0) {
+            $sql .= " LIMIT $offsetStr$nrows";
 		}
 
 		if ($secs) {
-			$rs = $this->CacheExecute($secs, $sql . " LIMIT $offsetStr$nrows", $inputarr);
+			$rs = $this->CacheExecute($secs,$sql, $inputarr);
 		} else {
-			$rs = $this->Execute($sql . " LIMIT $offsetStr$nrows", $inputarr);
+			$rs = $this->Execute($sql, $inputarr);
 		}
 		return $rs;
 	}


### PR DESCRIPTION
* Removed magic number
* Removed code duplication
* Removed long-dead link to what I can only assume is an explanation as to why a magic number is needed (it isn't)
* Reversed $nrows logic to only concatenate a LIMIT statement to existing sql if a limit is set when the method is called.