### PR TITLE
Add support for pdo-firebird, see #378, Add Meta extension points

### DIFF
--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -258,6 +258,64 @@ class ADODB_pdo extends ADOConnection {
 		return $this->_driver->MetaColumns($table,$normalize);
 	}
 
+	public function metaIndexes($table,$normalize=true)
+	{
+		if (method_exists($this->_driver,'metaIndexes'))
+			return $this->_driver->metaIndexes($table,$normalize);
+	}
+
+	/**
+	 * Return a list of Primary Keys for a specified table.
+	 *
+	 * @param string   $table
+	 * @param bool     $owner      (optional) not used in this driver
+	 *
+	 * @return string[]    Array of indexes
+	 */
+	public function metaPrimaryKeys($table,$owner=false)
+	{
+		if (method_exists($this->_driver,'metaPrimaryKeys'))
+			return $this->_driver->metaPrimaryKeys($table,$owner);
+	}
+
+	/**
+	 * Returns a list of Foreign Keys for a specified table.
+	 *
+	 * @param string   $table
+	 * @param bool     $owner      (optional) not used in this driver
+	 * @param bool     $upper
+	 * @param bool     $associative
+	 *
+	 * @return string[] where keys are tables, and values are foreign keys
+	 */
+	public function metaForeignKeys($table, $owner=false, $upper=false,$associative=false) {
+		if (method_exists($this->_driver,'metaForeignKeys'))
+			return $this->_driver->metaForeignKeys($table,$owner,$upper,$associative);
+	}
+
+	/**
+	 * List procedures or functions in an array.
+	 *
+	 * @param $procedureNamePattern A procedure name pattern; must match the procedure name as it is stored in the database.
+	 * @param $catalog              A catalog name; must match the catalog name as it is stored in the database.
+	 * @param $schemaPattern        A schema name pattern.
+	 *
+	 * @return false|array false if not supported, or array of procedures on current database with structure below
+	 *         Array(
+	 *           [name_of_procedure] => Array(
+	 *             [type] => PROCEDURE or FUNCTION
+	 *             [catalog] => Catalog_name
+	 *             [schema] => Schema_name
+	 *             [remarks] => explanatory comment on the procedure
+	 *           )
+	 *         )
+	 */
+	public function metaProcedures($procedureNamePattern = null, $catalog  = null, $schemaPattern  = null) {
+		if (method_exists($this->_driver,'metaProcedures'))
+			return $this->_driver->metaProcedures($procedureNamePattern,$catalog,$schemaPattern);
+		return false;
+	}
+
 	function InParameter(&$stmt,&$var,$name,$maxLen=4000,$type=false)
 	{
 		$obj = $stmt[1];

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -402,16 +402,16 @@ class ADODB_pdo extends ADOConnection {
 		return $err;
 	}
 
-    /**
-     * @param bool $auto_commit
-     * @return void
-     */
+	/**
+	 * @param bool $auto_commit
+	 * @return void
+	 */
 	function SetAutoCommit($auto_commit)
-    {
-        if(method_exists($this->_driver, 'SetAutoCommit')) {
-            $this->_driver->SetAutoCommit($auto_commit);
-        }
-    }
+	{
+		if(method_exists($this->_driver, 'SetAutoCommit')) {
+			$this->_driver->SetAutoCommit($auto_commit);
+		}
+	}
 
 	function SetTransactionMode($transaction_mode)
 	{

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -362,10 +362,10 @@ class ADODB_pdo extends ADOConnection {
 		return parent::SetTransactionMode($seqname);
 	}
 
-	function BeginTrans()
+	function beginTrans()
 	{
-		if(method_exists($this->_driver, 'BeginTrans')) {
-			return $this->_driver->BeginTrans();
+		if(method_exists($this->_driver, 'beginTrans')) {
+			return $this->_driver->beginTrans();
 		}
 
 		if (!$this->hasTransactions) {
@@ -381,10 +381,11 @@ class ADODB_pdo extends ADOConnection {
 		return $this->_connectionID->beginTransaction();
 	}
 
-	function CommitTrans($ok=true)
+	function commitTrans($ok=true)
 	{
-		if(method_exists($this->_driver, 'CommitTrans')) {
-			return $this->_driver->CommitTrans($ok);
+
+		if(method_exists($this->_driver, 'commitTrans')) {
+			return $this->_driver->commitTrans($ok);
 		}
 
 		if (!$this->hasTransactions) {
@@ -394,7 +395,7 @@ class ADODB_pdo extends ADOConnection {
 			return true;
 		}
 		if (!$ok) {
-			return $this->RollbackTrans();
+			return $this->rollbackTrans();
 		}
 		if ($this->transCnt) {
 			$this->transCnt -= 1;
@@ -448,10 +449,10 @@ class ADODB_pdo extends ADOConnection {
 		return $obj;
 	}
 
-	function CreateSequence($seqname='adodbseq',$startID=1)
+	public function createSequence($seqname='adodbseq',$startID=1)
 	{
-		if(method_exists($this->_driver, 'CreateSequence')) {
-			return $this->_driver->CreateSequence($seqname, $startID);
+		if(method_exists($this->_driver, 'createSequence')) {
+			return $this->_driver->createSequence($seqname, $startID);
 		}
 
 		return parent::CreateSequence($seqname, $startID);

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -141,6 +141,7 @@ class ADODB_pdo extends ADOConnection {
 				case 'oci':
 				case 'pgsql':
 				case 'sqlite':
+				case 'firebird':
 				default:
 					$argDSN .= ';dbname='.$argDatabasename;
 			}
@@ -191,6 +192,7 @@ class ADODB_pdo extends ADOConnection {
 				case 'pgsql':
 				case 'sqlite':
 				case 'sqlsrv':
+				case 'firebird':
 					include_once(ADODB_DIR.'/drivers/adodb-pdo_'.$this->dsnType.'.inc.php');
 					break;
 			}

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -532,6 +532,9 @@ class ADODB_pdo extends ADOConnection {
 
 	function _affectedrows()
 	{
+		if(method_exists($this->_driver, '_affectedrows'))
+			return $this->_driver->_affectedrows();
+		
 		return ($this->_stmt) ? $this->_stmt->rowCount() : 0;
 	}
 

--- a/drivers/adodb-pdo_firebird.inc.php
+++ b/drivers/adodb-pdo_firebird.inc.php
@@ -85,13 +85,10 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 		}
 
 		$retarr = array();
-		//OPN STUFF start
-		$dialect3 = ($this->dialect==3 ? true : false);
-		//OPN STUFF end
+		$dialect3 = $this->dialect == 3;
 		while (!$rs->EOF) { //print_r($rs->fields);
 			$fld = new ADOFieldObject();
 			$fld->name = trim($rs->fields[0]);
-			//OPN STUFF start
 			$this->_ConvertFieldType($fld, $rs->fields[7], $rs->fields[3], $rs->fields[4], $rs->fields[5], $rs->fields[6], $dialect3);
 			if (isset($rs->fields[1]) && $rs->fields[1]) {
 				$fld->not_null = true;
@@ -119,7 +116,6 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 			} else {
 				$fld->sub_type = null;
 			}
-			//OPN STUFF end
 			if ($ADODB_FETCH_MODE == ADODB_FETCH_NUM) $retarr[] = $fld;
 			else $retarr[strtoupper($fld->name)] = $fld;
 

--- a/drivers/adodb-pdo_firebird.inc.php
+++ b/drivers/adodb-pdo_firebird.inc.php
@@ -1,0 +1,423 @@
+<?php
+/**
+ * ADOdb PDO Firebird driver
+ *
+ * @version   v5.21.0-dev  ??-???-2016
+ * @copyright (c) 2019      Damien Regad, Mark Newnham and the ADOdb community
+ *
+ * Released under both BSD license and Lesser GPL library license.
+ * Whenever there is any discrepancy between the two licenses,
+ * the BSD license will take precedence. See License.txt.
+ *
+ * Set tabs to 4 for best viewing.
+ *
+ * Latest version is available at http://adodb.org/
+ *
+ * This version has only been tested on Firebird 3.0 and PHP 7
+ */
+
+class ADODB_pdo_firebird extends ADODB_pdo {
+
+	public $dialect = 3;
+
+	public $metaTablesSQL = "select lower(rdb\$relation_name) from rdb\$relations where rdb\$relation_name not like 'RDB\$%'";
+
+	public $metaColumnsSQL = "select lower(a.rdb\$field_name), a.rdb\$null_flag, a.rdb\$default_source, b.rdb\$field_length, b.rdb\$field_scale, b.rdb\$field_sub_type, b.rdb\$field_precision, b.rdb\$field_type from rdb\$relation_fields a, rdb\$fields b where a.rdb\$field_source = b.rdb\$field_name and a.rdb\$relation_name = '%s' order by a.rdb\$field_position asc";
+
+	var $arrayClass = 'ADORecordSet_array_pdo_firebird';
+
+	function _init($parentDriver)
+	{
+		$this->pdoDriver = $parentDriver;
+		//$parentDriver->_bindInputArray = true;
+		//$parentDriver->hasTransactions = false; // // should be set to false because of PDO SQLite driver not supporting changing autocommit mode
+		//$parentDriver->hasInsertID = true;
+	}
+
+	/**
+	 * Gets the version iformation from the server
+	 *
+	 * @return string[]
+	 */
+	public function serverInfo()
+	{
+		$arr['dialect'] = $this->dialect;
+		switch($arr['dialect']) {
+		case '':
+		case '1': $s = 'Firebird Dialect 1'; break;
+		case '2': $s = 'Firebird Dialect 2'; break;
+		default:
+		case '3': $s = 'Firebird Dialect 3'; break;
+		}
+		$arr['version'] = ADOConnection::_findvers($s);
+		$arr['description'] = $s;
+		return $arr;
+	}
+
+	/**
+	 * Returns the tables in the database
+	 * @param	mixed	$ttype
+	 * @param	bool	$showSchema
+	 * @param	mixed	$mask
+	 *
+	 * @return	string[]
+	 */
+	public function metaTables($ttype=false,$showSchema=false,$mask=false)
+	{
+		$ret = ADOConnection::MetaTables($ttype,$showSchema);
+
+		return $ret;
+	}
+
+	public function metaColumns($table, $normalize=true)
+	{
+		global $ADODB_FETCH_MODE;
+
+		$save = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+
+		$rs = $this->Execute(sprintf($this->metaColumnsSQL,strtoupper($table)));
+
+		$ADODB_FETCH_MODE = $save;
+		$false = false;
+		if ($rs === false) {
+			return $false;
+		}
+
+		$retarr = array();
+		//OPN STUFF start
+		$dialect3 = ($this->dialect==3 ? true : false);
+		//OPN STUFF end
+		while (!$rs->EOF) { //print_r($rs->fields);
+			$fld = new ADOFieldObject();
+			$fld->name = trim($rs->fields[0]);
+			//OPN STUFF start
+			$this->_ConvertFieldType($fld, $rs->fields[7], $rs->fields[3], $rs->fields[4], $rs->fields[5], $rs->fields[6], $dialect3);
+			if (isset($rs->fields[1]) && $rs->fields[1]) {
+				$fld->not_null = true;
+			}
+			if (isset($rs->fields[2])) {
+
+				$fld->has_default = true;
+				$d = substr($rs->fields[2],strlen('default '));
+				switch ($fld->type)
+				{
+				case 'smallint':
+				case 'integer': $fld->default_value = (int) $d; break;
+				case 'char':
+				case 'blob':
+				case 'text':
+				case 'varchar': $fld->default_value = (string) substr($d,1,strlen($d)-2); break;
+				case 'double':
+				case 'float': $fld->default_value = (float) $d; break;
+				default: $fld->default_value = $d; break;
+				}
+		//	case 35:$tt = 'TIMESTAMP'; break;
+			}
+			if ((isset($rs->fields[5])) && ($fld->type == 'blob')) {
+				$fld->sub_type = $rs->fields[5];
+			} else {
+				$fld->sub_type = null;
+			}
+			//OPN STUFF end
+			if ($ADODB_FETCH_MODE == ADODB_FETCH_NUM) $retarr[] = $fld;
+			else $retarr[strtoupper($fld->name)] = $fld;
+
+			$rs->MoveNext();
+		}
+		$rs->Close();
+		if ( empty($retarr)) return $false;
+		else return $retarr;
+	}
+
+	public function metaIndexes ($table, $primary = FALSE, $owner=false)
+	{
+		// save old fetch mode
+		global $ADODB_FETCH_MODE;
+		$false = false;
+		$save = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+		if ($this->fetchMode !== FALSE) {
+				$savem = $this->SetFetchMode(FALSE);
+		}
+		$table = strtoupper($table);
+		$sql = "SELECT * FROM RDB\$INDICES WHERE RDB\$RELATION_NAME = '".$table."'";
+		if (!$primary) {
+			$sql .= " AND RDB\$INDEX_NAME NOT LIKE 'RDB\$%'";
+		} else {
+			$sql .= " AND RDB\$INDEX_NAME NOT LIKE 'RDB\$FOREIGN%'";
+		}
+
+		// get index details
+		$rs = $this->Execute($sql);
+		if (!is_object($rs)) {
+			// restore fetchmode
+			if (isset($savem)) {
+				$this->SetFetchMode($savem);
+			}
+			$ADODB_FETCH_MODE = $save;
+			return $false;
+		}
+
+		$indexes = array();
+		while ($row = $rs->FetchRow()) {
+			$index = $row[0];
+			if (!isset($indexes[$index])) {
+				if (is_null($row[3])) {
+					$row[3] = 0;
+				}
+				$indexes[$index] = array(
+					'unique' => ($row[3] == 1),
+					'columns' => array()
+				);
+			}
+			$sql = "SELECT * FROM RDB\$INDEX_SEGMENTS WHERE RDB\$INDEX_NAME = '".$index."' ORDER BY RDB\$FIELD_POSITION ASC";
+			$rs1 = $this->Execute($sql);
+			while ($row1 = $rs1->FetchRow()) {
+				$indexes[$index]['columns'][$row1[2]] = $row1[1];
+			}
+		}
+		// restore fetchmode
+		if (isset($savem)) {
+			$this->SetFetchMode($savem);
+		}
+		$ADODB_FETCH_MODE = $save;
+
+		return $indexes;
+	}
+
+	public function metaPrimaryKeys($table,$owner_notused=false,$internalKey=false)
+	{
+		if ($internalKey) {
+			return array('RDB$DB_KEY');
+		}
+
+		$table = strtoupper($table);
+
+		$sql = 'SELECT S.RDB$FIELD_NAME AFIELDNAME
+	FROM RDB$INDICES I JOIN RDB$INDEX_SEGMENTS S ON I.RDB$INDEX_NAME=S.RDB$INDEX_NAME
+	WHERE I.RDB$RELATION_NAME=\''.$table.'\' and I.RDB$INDEX_NAME like \'RDB$PRIMARY%\'
+	ORDER BY I.RDB$INDEX_NAME,S.RDB$FIELD_POSITION';
+
+		$a = $this->GetCol($sql,false,true);
+		if ($a && sizeof($a)>0) return $a;
+		return false;
+	}
+
+	public function createSequence($seqname = 'adodbseq', $startID = 1)
+	{
+		$ok = $this->execute("CREATE SEQUENCE $seqname");
+		if (!$ok)
+			return false;
+
+		return $this->execute("ALTER SEQUENCE $seqname RESTART WITH ".($startID-1));
+	}
+
+	public function dropSequence($seqname = 'adodbseq')
+	{
+		$seqname = strtoupper($seqname);
+		return $this->Execute("DROP SEQUENCE $seqname");
+	}
+
+
+	public function _affectedrows()
+	{
+		return fbird_affected_rows( $this->_transactionID ? $this->_transactionID : $this->_connectionID );
+	}
+
+	public function genId($seqname='adodbseq',$startID=1)
+	{
+		$getnext = ("SELECT Gen_ID($seqname,1) FROM RDB\$DATABASE");
+		$rs = @$this->execute($getnext);
+		if (!$rs) 
+		{
+			$this->execute(("CREATE SEQUENCE $seqname" ));
+			$this->execute("ALTER SEQUENCE $seqname RESTART WITH ".($startID-1).';');
+			$rs = $this->execute($getnext);
+		}
+		if ($rs && !$rs->EOF) {
+			$this->genID = (integer) reset($rs->fields);
+		}
+		else {
+			$this->genID = 0; // false
+		}
+
+		if ($rs) {
+			$rs->Close();
+		}
+
+		return $this->genID;
+	}
+
+	public function selectLimit($sql,$nrows=-1,$offset=-1,$inputarr=false, $secs=0)
+	{
+		$nrows = (integer) $nrows;
+		$offset = (integer) $offset;
+		$str = 'SELECT ';
+		if ($nrows >= 0) $str .= "FIRST $nrows ";
+		$str .=($offset>=0) ? "SKIP $offset " : '';
+
+		$sql = preg_replace('/^[ \t]*select/i',$str,$sql);
+		if ($secs)
+			$rs = $this->cacheExecute($secs,$sql,$inputarr);
+		else
+			$rs = $this->execute($sql,$inputarr);
+
+		return $rs;
+	}
+
+	/**
+	* Sets the appropriate type into the $fld variable
+	*
+	* @param	string		$fld		By reference
+	* @param	int			$ftype
+	* @param	int			$flen
+	* @param	int			$fscale
+	* @param	int			$fsubtype
+	* @param	int			$fprecision
+	* @param	bool		$dialect3
+	*/
+	final private function _convertFieldType(&$fld, $ftype, $flen, $fscale, $fsubtype, $fprecision, $dialect3)
+	{
+		$fscale = abs($fscale);
+		$fld->max_length = $flen;
+		$fld->scale = null;
+		switch($ftype){
+			case 7:
+			case 8:
+				if ($dialect3) {
+					switch($fsubtype){
+						case 0:
+							$fld->type = ($ftype == 7 ? 'smallint' : 'integer');
+							break;
+						case 1:
+							$fld->type = 'numeric';
+							$fld->max_length = $fprecision;
+							$fld->scale = $fscale;
+							break;
+						case 2:
+							$fld->type = 'decimal';
+							$fld->max_length = $fprecision;
+							$fld->scale = $fscale;
+							break;
+					} // switch
+				} else {
+					if ($fscale !=0) {
+						$fld->type = 'decimal';
+						$fld->scale = $fscale;
+						$fld->max_length = ($ftype == 7 ? 4 : 9);
+					} else {
+						$fld->type = ($ftype == 7 ? 'smallint' : 'integer');
+					}
+				}
+				break;
+			case 16:
+				if ($dialect3) {
+					switch($fsubtype){
+						case 0:
+							$fld->type = 'decimal';
+							$fld->max_length = 18;
+							$fld->scale = 0;
+							break;
+						case 1:
+							$fld->type = 'numeric';
+							$fld->max_length = $fprecision;
+							$fld->scale = $fscale;
+							break;
+						case 2:
+							$fld->type = 'decimal';
+							$fld->max_length = $fprecision;
+							$fld->scale = $fscale;
+							break;
+					} // switch
+				}
+				break;
+			case 10:
+				$fld->type = 'float';
+				break;
+			case 14:
+				$fld->type = 'char';
+				break;
+			case 27:
+				if ($fscale !=0) {
+					$fld->type = 'decimal';
+					$fld->max_length = 15;
+					$fld->scale = 5;
+				} else {
+					$fld->type = 'double';
+				}
+				break;
+			case 35:
+				if ($dialect3) {
+					$fld->type = 'timestamp';
+				} else {
+					$fld->type = 'date';
+				}
+				break;
+			case 12:
+				$fld->type = 'date';
+				break;
+			case 13:
+				$fld->type = 'time';
+				break;
+			case 37:
+				$fld->type = 'varchar';
+				break;
+			case 40:
+				$fld->type = 'cstring';
+				break;
+			case 261:
+				$fld->type = 'blob';
+				$fld->max_length = -1;
+				break;
+		} // switch
+	}
+}
+
+class ADORecordSet_pdo_firebird extends ADORecordSet_pdo
+{
+
+	public $databaseType = "pdo_firebird";
+
+	/**
+	 * returns the field object
+	 *
+	 * @param  int $fieldOffset Optional field offset
+	 *
+	 * @return object The ADOFieldObject describing the field
+	 */
+	public function fetchField($fieldOffset = 0)
+	{
+	}
+
+}
+
+class ADORecordSet_array_pdo_firebird extends ADORecordSet_array_pdo
+{
+
+	public $databaseType = "pdo_firebird";
+	public $canSeek = true;
+
+	/**
+	 * returns the field object
+	 *
+	 * @param  int $fieldOffset Optional field offset
+	 *
+	 * @return object The ADOFieldObject describing the field
+	 */
+	public function fetchField($fieldOffset = 0)
+	{
+
+		$fld = new ADOFieldObject;
+		$fld->name = $fieldOffset;
+		$fld->type = 'C';
+		$fld->max_length = 0;
+
+		// This needs to be populated from the metadata
+		$fld->not_null = false;
+		$fld->has_default = false;
+		$fld->default_value = 'null';
+
+		return $fld;
+	}
+}

--- a/drivers/adodb-pdo_firebird.inc.php
+++ b/drivers/adodb-pdo_firebird.inc.php
@@ -16,12 +16,10 @@
  * This version has only been tested on Firebird 3.0 and PHP 7
  */
 
-class ADODB_pdo_firebird extends ADODB_pdo {
-
+class ADODB_pdo_firebird extends ADODB_pdo
+{
 	public $dialect = 3;
-
 	public $metaTablesSQL = "select lower(rdb\$relation_name) from rdb\$relations where rdb\$relation_name not like 'RDB\$%'";
-
 	public $metaColumnsSQL = "select lower(a.rdb\$field_name), a.rdb\$null_flag, a.rdb\$default_source, b.rdb\$field_length, b.rdb\$field_scale, b.rdb\$field_sub_type, b.rdb\$field_precision, b.rdb\$field_type from rdb\$relation_fields a, rdb\$fields b where a.rdb\$field_source = b.rdb\$field_name and a.rdb\$relation_name = '%s' order by a.rdb\$field_position asc";
 
 	var $arrayClass = 'ADORecordSet_array_pdo_firebird';
@@ -42,12 +40,18 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 	public function serverInfo()
 	{
 		$arr['dialect'] = $this->dialect;
-		switch($arr['dialect']) {
-		case '':
-		case '1': $s = 'Firebird Dialect 1'; break;
-		case '2': $s = 'Firebird Dialect 2'; break;
-		default:
-		case '3': $s = 'Firebird Dialect 3'; break;
+		switch ($arr['dialect']) {
+			case '':
+			case '1':
+				$s = 'Firebird Dialect 1';
+				break;
+			case '2':
+				$s = 'Firebird Dialect 2';
+				break;
+			default:
+			case '3':
+				$s = 'Firebird Dialect 3';
+				break;
 		}
 		$arr['version'] = ADOConnection::_findvers($s);
 		$arr['description'] = $s;
@@ -55,28 +59,29 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 	}
 
 	/**
-	 * Returns the tables in the database
-	 * @param	mixed	$ttype
-	 * @param	bool	$showSchema
-	 * @param	mixed	$mask
+	 * Returns the tables in the database.
 	 *
-	 * @return	string[]
+	 * @param mixed $ttype
+	 * @param bool  $showSchema
+	 * @param mixed $mask
+	 *
+	 * @return    string[]
 	 */
-	public function metaTables($ttype=false,$showSchema=false,$mask=false)
+	public function metaTables($ttype = false, $showSchema = false, $mask = false)
 	{
-		$ret = ADOConnection::MetaTables($ttype,$showSchema);
+		$ret = ADOConnection::MetaTables($ttype, $showSchema);
 
 		return $ret;
 	}
 
-	public function metaColumns($table, $normalize=true)
+	public function metaColumns($table, $normalize = true)
 	{
 		global $ADODB_FETCH_MODE;
 
 		$save = $ADODB_FETCH_MODE;
 		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
 
-		$rs = $this->Execute(sprintf($this->metaColumnsSQL,strtoupper($table)));
+		$rs = $this->Execute(sprintf($this->metaColumnsSQL, strtoupper($table)));
 
 		$ADODB_FETCH_MODE = $save;
 
@@ -89,54 +94,67 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 		while (!$rs->EOF) { //print_r($rs->fields);
 			$fld = new ADOFieldObject();
 			$fld->name = trim($rs->fields[0]);
-			$this->_ConvertFieldType($fld, $rs->fields[7], $rs->fields[3], $rs->fields[4], $rs->fields[5], $rs->fields[6], $dialect3);
+			$this->_ConvertFieldType($fld, $rs->fields[7], $rs->fields[3], $rs->fields[4], $rs->fields[5],
+				$rs->fields[6], $dialect3);
 			if (isset($rs->fields[1]) && $rs->fields[1]) {
 				$fld->not_null = true;
 			}
 			if (isset($rs->fields[2])) {
 
 				$fld->has_default = true;
-				$d = substr($rs->fields[2],strlen('default '));
-				switch ($fld->type)
-				{
-				case 'smallint':
-				case 'integer': $fld->default_value = (int) $d; break;
-				case 'char':
-				case 'blob':
-				case 'text':
-				case 'varchar': $fld->default_value = (string) substr($d,1,strlen($d)-2); break;
-				case 'double':
-				case 'float': $fld->default_value = (float) $d; break;
-				default: $fld->default_value = $d; break;
+				$d = substr($rs->fields[2], strlen('default '));
+				switch ($fld->type) {
+					case 'smallint':
+					case 'integer':
+						$fld->default_value = (int)$d;
+						break;
+					case 'char':
+					case 'blob':
+					case 'text':
+					case 'varchar':
+						$fld->default_value = (string)substr($d, 1, strlen($d) - 2);
+						break;
+					case 'double':
+					case 'float':
+						$fld->default_value = (float)$d;
+						break;
+					default:
+						$fld->default_value = $d;
+						break;
 				}
-		//	case 35:$tt = 'TIMESTAMP'; break;
 			}
 			if ((isset($rs->fields[5])) && ($fld->type == 'blob')) {
 				$fld->sub_type = $rs->fields[5];
 			} else {
 				$fld->sub_type = null;
 			}
-			if ($ADODB_FETCH_MODE == ADODB_FETCH_NUM) $retarr[] = $fld;
-			else $retarr[strtoupper($fld->name)] = $fld;
+			if ($ADODB_FETCH_MODE == ADODB_FETCH_NUM) {
+				$retarr[] = $fld;
+			} else {
+				$retarr[strtoupper($fld->name)] = $fld;
+			}
 
 			$rs->MoveNext();
 		}
 		$rs->Close();
-		if ( empty($retarr)) return false;
-		else return $retarr;
+		if (empty($retarr)) {
+			return false;
+		} else {
+			return $retarr;
+		}
 	}
 
-	public function metaIndexes ($table, $primary = FALSE, $owner=false)
+	public function metaIndexes($table, $primary = false, $owner = false)
 	{
 		// save old fetch mode
 		global $ADODB_FETCH_MODE;
 		$save = $ADODB_FETCH_MODE;
 		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
-		if ($this->fetchMode !== FALSE) {
-				$savem = $this->SetFetchMode(FALSE);
+		if ($this->fetchMode !== false) {
+			$savem = $this->SetFetchMode(false);
 		}
 		$table = strtoupper($table);
-		$sql = "SELECT * FROM RDB\$INDICES WHERE RDB\$RELATION_NAME = '".$table."'";
+		$sql = "SELECT * FROM RDB\$INDICES WHERE RDB\$RELATION_NAME = '" . $table . "'";
 		if (!$primary) {
 			$sql .= " AND RDB\$INDEX_NAME NOT LIKE 'RDB\$%'";
 		} else {
@@ -166,7 +184,7 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 					'columns' => array()
 				);
 			}
-			$sql = "SELECT * FROM RDB\$INDEX_SEGMENTS WHERE RDB\$INDEX_NAME = '".$index."' ORDER BY RDB\$FIELD_POSITION ASC";
+			$sql = "SELECT * FROM RDB\$INDEX_SEGMENTS WHERE RDB\$INDEX_NAME = '" . $index . "' ORDER BY RDB\$FIELD_POSITION ASC";
 			$rs1 = $this->Execute($sql);
 			while ($row1 = $rs1->FetchRow()) {
 				$indexes[$index]['columns'][$row1[2]] = $row1[1];
@@ -181,7 +199,7 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 		return $indexes;
 	}
 
-	public function metaPrimaryKeys($table,$owner_notused=false,$internalKey=false)
+	public function metaPrimaryKeys($table, $owner_notused = false, $internalKey = false)
 	{
 		if ($internalKey) {
 			return array('RDB$DB_KEY');
@@ -191,21 +209,24 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 
 		$sql = 'SELECT S.RDB$FIELD_NAME AFIELDNAME
 	FROM RDB$INDICES I JOIN RDB$INDEX_SEGMENTS S ON I.RDB$INDEX_NAME=S.RDB$INDEX_NAME
-	WHERE I.RDB$RELATION_NAME=\''.$table.'\' and I.RDB$INDEX_NAME like \'RDB$PRIMARY%\'
+	WHERE I.RDB$RELATION_NAME=\'' . $table . '\' and I.RDB$INDEX_NAME like \'RDB$PRIMARY%\'
 	ORDER BY I.RDB$INDEX_NAME,S.RDB$FIELD_POSITION';
 
-		$a = $this->GetCol($sql,false,true);
-		if ($a && sizeof($a)>0) return $a;
+		$a = $this->GetCol($sql, false, true);
+		if ($a && sizeof($a) > 0) {
+			return $a;
+		}
 		return false;
 	}
 
 	public function createSequence($seqname = 'adodbseq', $startID = 1)
 	{
 		$ok = $this->execute("CREATE SEQUENCE $seqname");
-		if (!$ok)
+		if (!$ok) {
 			return false;
+		}
 
-		return $this->execute("ALTER SEQUENCE $seqname RESTART WITH ".($startID-1));
+		return $this->execute("ALTER SEQUENCE $seqname RESTART WITH " . ($startID - 1));
 	}
 
 	public function dropSequence($seqname = 'adodbseq')
@@ -217,23 +238,21 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 
 	public function _affectedrows()
 	{
-		return fbird_affected_rows( $this->_transactionID ? $this->_transactionID : $this->_connectionID );
+		return fbird_affected_rows($this->_transactionID ? $this->_transactionID : $this->_connectionID);
 	}
 
-	public function genId($seqname='adodbseq',$startID=1)
+	public function genId($seqname = 'adodbseq', $startID = 1)
 	{
 		$getnext = ("SELECT Gen_ID($seqname,1) FROM RDB\$DATABASE");
 		$rs = @$this->execute($getnext);
-		if (!$rs) 
-		{
-			$this->execute(("CREATE SEQUENCE $seqname" ));
-			$this->execute("ALTER SEQUENCE $seqname RESTART WITH ".($startID-1).';');
+		if (!$rs) {
+			$this->execute(("CREATE SEQUENCE $seqname"));
+			$this->execute("ALTER SEQUENCE $seqname RESTART WITH " . ($startID - 1) . ';');
 			$rs = $this->execute($getnext);
 		}
 		if ($rs && !$rs->EOF) {
-			$this->genID = (integer) reset($rs->fields);
-		}
-		else {
+			$this->genID = (integer)reset($rs->fields);
+		} else {
 			$this->genID = 0; // false
 		}
 
@@ -244,44 +263,47 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 		return $this->genID;
 	}
 
-	public function selectLimit($sql,$nrows=-1,$offset=-1,$inputarr=false, $secs=0)
+	public function selectLimit($sql, $nrows = -1, $offset = -1, $inputarr = false, $secs = 0)
 	{
-		$nrows = (integer) $nrows;
-		$offset = (integer) $offset;
+		$nrows = (integer)$nrows;
+		$offset = (integer)$offset;
 		$str = 'SELECT ';
-		if ($nrows >= 0) $str .= "FIRST $nrows ";
-		$str .=($offset>=0) ? "SKIP $offset " : '';
+		if ($nrows >= 0) {
+			$str .= "FIRST $nrows ";
+		}
+		$str .= ($offset >= 0) ? "SKIP $offset " : '';
 
-		$sql = preg_replace('/^[ \t]*select/i',$str,$sql);
-		if ($secs)
-			$rs = $this->cacheExecute($secs,$sql,$inputarr);
-		else
-			$rs = $this->execute($sql,$inputarr);
+		$sql = preg_replace('/^[ \t]*select/i', $str, $sql);
+		if ($secs) {
+			$rs = $this->cacheExecute($secs, $sql, $inputarr);
+		} else {
+			$rs = $this->execute($sql, $inputarr);
+		}
 
 		return $rs;
 	}
 
 	/**
-	* Sets the appropriate type into the $fld variable
-	*
-	* @param	string		$fld		By reference
-	* @param	int			$ftype
-	* @param	int			$flen
-	* @param	int			$fscale
-	* @param	int			$fsubtype
-	* @param	int			$fprecision
-	* @param	bool		$dialect3
-	*/
+	 * Sets the appropriate type into the $fld variable
+	 *
+	 * @param ADOFieldObject $fld By reference
+	 * @param int            $ftype
+	 * @param int            $flen
+	 * @param int            $fscale
+	 * @param int            $fsubtype
+	 * @param int            $fprecision
+	 * @param bool           $dialect3
+	 */
 	final private function _convertFieldType(&$fld, $ftype, $flen, $fscale, $fsubtype, $fprecision, $dialect3)
 	{
 		$fscale = abs($fscale);
 		$fld->max_length = $flen;
 		$fld->scale = null;
-		switch($ftype){
+		switch ($ftype) {
 			case 7:
 			case 8:
 				if ($dialect3) {
-					switch($fsubtype){
+					switch ($fsubtype) {
 						case 0:
 							$fld->type = ($ftype == 7 ? 'smallint' : 'integer');
 							break;
@@ -297,7 +319,7 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 							break;
 					} // switch
 				} else {
-					if ($fscale !=0) {
+					if ($fscale != 0) {
 						$fld->type = 'decimal';
 						$fld->scale = $fscale;
 						$fld->max_length = ($ftype == 7 ? 4 : 9);
@@ -308,7 +330,7 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 				break;
 			case 16:
 				if ($dialect3) {
-					switch($fsubtype){
+					switch ($fsubtype) {
 						case 0:
 							$fld->type = 'decimal';
 							$fld->max_length = 18;
@@ -334,7 +356,7 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 				$fld->type = 'char';
 				break;
 			case 27:
-				if ($fscale !=0) {
+				if ($fscale != 0) {
 					$fld->type = 'decimal';
 					$fld->max_length = 15;
 					$fld->scale = 5;
@@ -377,26 +399,24 @@ class ADORecordSet_pdo_firebird extends ADORecordSet_pdo
 	/**
 	 * returns the field object
 	 *
-	 * @param  int $fieldOffset Optional field offset
+	 * @param int $fieldOffset Optional field offset
 	 *
 	 * @return object The ADOFieldObject describing the field
 	 */
 	public function fetchField($fieldOffset = 0)
 	{
 	}
-
 }
 
 class ADORecordSet_array_pdo_firebird extends ADORecordSet_array_pdo
 {
-
 	public $databaseType = "pdo_firebird";
 	public $canSeek = true;
 
 	/**
 	 * returns the field object
 	 *
-	 * @param  int $fieldOffset Optional field offset
+	 * @param int $fieldOffset Optional field offset
 	 *
 	 * @return object The ADOFieldObject describing the field
 	 */

--- a/drivers/adodb-pdo_firebird.inc.php
+++ b/drivers/adodb-pdo_firebird.inc.php
@@ -16,6 +16,9 @@
  * This version has only been tested on Firebird 3.0 and PHP 7
  */
 
+/**
+ * Class ADODB_pdo_firebird
+ */
 class ADODB_pdo_firebird extends ADODB_pdo
 {
 	public $dialect = 3;
@@ -391,6 +394,9 @@ class ADODB_pdo_firebird extends ADODB_pdo
 	}
 }
 
+/**
+ * Class ADORecordSet_pdo_firebird
+ */
 class ADORecordSet_pdo_firebird extends ADORecordSet_pdo
 {
 
@@ -408,6 +414,9 @@ class ADORecordSet_pdo_firebird extends ADORecordSet_pdo
 	}
 }
 
+/**
+ * Class ADORecordSet_array_pdo_firebird
+ */
 class ADORecordSet_array_pdo_firebird extends ADORecordSet_array_pdo
 {
 	public $databaseType = "pdo_firebird";

--- a/drivers/adodb-pdo_firebird.inc.php
+++ b/drivers/adodb-pdo_firebird.inc.php
@@ -79,9 +79,9 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 		$rs = $this->Execute(sprintf($this->metaColumnsSQL,strtoupper($table)));
 
 		$ADODB_FETCH_MODE = $save;
-		$false = false;
+
 		if ($rs === false) {
-			return $false;
+			return false;
 		}
 
 		$retarr = array();
@@ -122,7 +122,7 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 			$rs->MoveNext();
 		}
 		$rs->Close();
-		if ( empty($retarr)) return $false;
+		if ( empty($retarr)) return false;
 		else return $retarr;
 	}
 
@@ -130,7 +130,6 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 	{
 		// save old fetch mode
 		global $ADODB_FETCH_MODE;
-		$false = false;
 		$save = $ADODB_FETCH_MODE;
 		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
 		if ($this->fetchMode !== FALSE) {
@@ -152,7 +151,7 @@ class ADODB_pdo_firebird extends ADODB_pdo {
 				$this->SetFetchMode($savem);
 			}
 			$ADODB_FETCH_MODE = $save;
-			return $false;
+			return false;
 		}
 
 		$indexes = array();


### PR DESCRIPTION
This change includes the first release of the pdo_firebird driver, as well as extension points for the following  Meta functions within the pdo driver:
 - metaIndexes()
- metaPrimaryKeys()
- metaForeignKeys()
- metaProcedures()

The first release of the pdo-firebird driver is known to have the following limitations:

- Only supports dialect3
- Only tested with PHP7
- Only tested with Firebird 3
- function getRowAssoc() fails because PDO::firebird does not support getColumnMeta()
- function moveFirst() currently fails for unknown reasons