### PR TITLE
Removal of session_module_name('user') for PHP 7.2+ database session support.

### DIFF
--- a/session/adodb-session.php
+++ b/session/adodb-session.php
@@ -442,7 +442,6 @@ class ADODB_Session {
 	/*!
 	*/
 	function _init() {
-		session_module_name('user');
 		session_set_save_handler(
 			array('ADODB_Session', 'open'),
 			array('ADODB_Session', 'close'),

--- a/session/adodb-session2.php
+++ b/session/adodb-session2.php
@@ -464,7 +464,6 @@ class ADODB_Session {
 	/*!
 	*/
 	static function _init() {
-		session_module_name('user');
 		session_set_save_handler(
 			array('ADODB_Session', 'open'),
 			array('ADODB_Session', 'close'),

--- a/session/old/adodb-cryptsession.php
+++ b/session/old/adodb-cryptsession.php
@@ -302,7 +302,6 @@ function adodb_sess_gc($maxlifetime) {
 	return true;
 }
 
-session_module_name('user');
 session_set_save_handler(
 	"adodb_sess_open",
 	"adodb_sess_close",

--- a/session/old/adodb-session-clob.php
+++ b/session/old/adodb-session-clob.php
@@ -426,7 +426,6 @@ function adodb_sess_gc($maxlifetime)
 	return true;
 }
 
-session_module_name('user');
 session_set_save_handler(
 	"adodb_sess_open",
 	"adodb_sess_close",

--- a/session/old/adodb-session.php
+++ b/session/old/adodb-session.php
@@ -417,7 +417,6 @@ function adodb_sess_gc($maxlifetime)
 	return true;
 }
 
-session_module_name('user');
 session_set_save_handler(
 	"adodb_sess_open",
 	"adodb_sess_close",


### PR DESCRIPTION
Resolves #449 Removal of `session_module_name('user')` from session related files.

According to the documention:
http://php.net/session_module_name

> 7.2.0 - It is now explicitly forbidden to set the module name to "user". Formerly, this has been silently ignored.

I have tested this removal on PHP 7.1 and 7.2, and it works as expected.



