### PR TITLE
Fixed: Connecting to non-standard port with mysqlnd.

### DIFF
--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -131,6 +131,10 @@ class ADODB_mysqli extends ADOConnection {
 		}
 
 		#if (!empty($this->port)) $argHostname .= ":".$this->port;
+		
+		// NOTE: Connecting on non-standard port failed when mysqlnd was active and port was not part of host.
+		if (function_exists('mysqli_fetch_all') && !empty($this->port)) $argHostname .= ":" . $this->port;
+
 		$ok = @mysqli_real_connect($this->_connectionID,
 					$argHostname,
 					$argUsername,


### PR DESCRIPTION
Connecting to MySQL server with port other than 3306 was not working when mysqlnd extension was enabled and mysqli type of driver was used. Having it part of hostname got it working.