### PR TITLE
warning for empty mysqli_result

### DIFF
--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -1135,7 +1135,7 @@ class ADORecordSet_mysqli extends ADORecordSet{
 			}
 		}
 
-		if($this->_queryID instanceof mysqli_result) {
+		if($this->_queryID instanceof mysqli_result && (!empty(implode('',(array)$this->_queryID)))) {
 			mysqli_free_result($this->_queryID);
 		}
 		$this->_queryID = false;


### PR DESCRIPTION
Warning is shown in function _close for empty mysqli_result (see #491)