### PR TITLE
Remove unnecessary srand() calls

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -237,11 +237,6 @@ if (!defined('_ADODB_LAYER')) {
 			}
 		}
 
-
-		// Initialize random number generator for randomizing cache flushes
-		// -- note Since PHP 4.2.0, the seed  becomes optional and defaults to a random value if omitted.
-		srand(((double)microtime())*1000000);
-
 		/**
 		 * ADODB version as a string.
 		 */
@@ -3698,7 +3693,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	 */
 	function getAssoc($force_array = false, $first2cols = false)
 	{
-		
+
 		global $ADODB_FETCH_MODE;
 		/*
 		* Insufficient rows to show data
@@ -3764,7 +3759,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 			* The key is not case processed
 			*/
 			$key = array_shift($myFields);
-			
+
 			switch ($showArrayMethod)
 			{
 			case 0:

--- a/session/crypt.inc.php
+++ b/session/crypt.inc.php
@@ -16,7 +16,6 @@ class MD5Crypt{
 
 		function Encrypt($txt,$key)
 		{
-				srand((double)microtime()*1000000);
 				$encrypt_key = md5(rand(0,32000));
 				$ctr=0;
 				$tmp = "";
@@ -45,7 +44,6 @@ class MD5Crypt{
 		function RandPass()
 		{
 				$randomPassword = "";
-				srand((double)microtime()*1000000);
 				for($i=0;$i<8;$i++)
 				{
 						$randnumber = rand(48,120);
@@ -83,7 +81,6 @@ class SHA1Crypt{
 		function Encrypt($txt,$key)
 		{
 
-				srand((double)microtime()*1000000);
 				$encrypt_key = sha1(rand(0,32000));
 				$ctr=0;
 				$tmp = "";
@@ -133,8 +130,6 @@ class SHA1Crypt{
 		function RandPass()
 		{
 				$randomPassword = "";
-				srand((double)microtime()*1000000);
-
 				for($i=0;$i<8;$i++)
 				{
 

--- a/session/old/crypt.inc.php
+++ b/session/old/crypt.inc.php
@@ -16,7 +16,6 @@ class MD5Crypt{
 
 		function Encrypt($txt,$key)
 		{
-				srand((double)microtime()*1000000);
 				$encrypt_key = md5(rand(0,32000));
 				$ctr=0;
 				$tmp = "";
@@ -45,7 +44,6 @@ class MD5Crypt{
 		function RandPass()
 		{
 				$randomPassword = "";
-				srand((double)microtime()*1000000);
 				for($i=0;$i<8;$i++)
 				{
 						$randnumber = rand(48,120);


### PR DESCRIPTION
srand() should not be called manually, unless one has a better way to
initialise the already-initialised random seend

the way the current srand() call is made is buggy, and will lead to
duplicate random seeds if called often enough. Because the current call
will loose the timestamp part, and will only use the first 6 chars from
the current microsecond, but the system might not have a high-enough
timer resolution, so the actual pool of random seeds gets even smaller