### PR TITLE
Fix Active Record field names case

### DIFF
--- a/adodb-active-record.inc.php
+++ b/adodb-active-record.inc.php
@@ -466,7 +466,7 @@ class ADODB_Active_Record {
 		$attr = array();
 		$keys = array();
 
-		switch($ADODB_ASSOC_CASE) {
+		switch(ADODB_ASSOC_CASE) {
 		case 0:
 			foreach($cols as $name => $fldobj) {
 				$name = strtolower($name);


### PR DESCRIPTION
When I have a class extending ADODB_Active_Record, I have only lowercase field names instead native-case field names. When the value of ADODB_ASSOC_CASE is 2, the value of $ADODB_ASSOC_CASE is NULL, so we are going to the case 0 of the switch!