### PR TITLE
Auto reconnect to database if connection is lost for mysqli and pdo

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -693,7 +693,7 @@ if (!defined('_ADODB_LAYER')) {
 			$this->user = $argUsername;
 		}
 		if ($argPassword != "") {
-			$this->password = 'not stored'; // not stored for security reasons
+			$this->password = $argPassword;
 		}
 		if ($argDatabaseName != "") {
 			$this->database = $argDatabaseName;
@@ -702,11 +702,11 @@ if (!defined('_ADODB_LAYER')) {
 		$this->_isPersistentConnection = false;
 
 		if ($forceNew) {
-			if ($rez=$this->_nconnect($this->host, $this->user, $argPassword, $this->database)) {
+			if ($rez=$this->_nconnect($this->host, $this->user, $this->password, $this->database)) {
 				return true;
 			}
 		} else {
-			if ($rez=$this->_connect($this->host, $this->user, $argPassword, $this->database)) {
+			if ($rez=$this->_connect($this->host, $this->user, $this->password, $this->database)) {
 				return true;
 			}
 		}
@@ -776,7 +776,7 @@ if (!defined('_ADODB_LAYER')) {
 			$this->user = $argUsername;
 		}
 		if ($argPassword != "") {
-			$this->password = 'not stored';
+			$this->password = $argPassword;
 		}
 		if ($argDatabaseName != "") {
 			$this->database = $argDatabaseName;
@@ -784,7 +784,7 @@ if (!defined('_ADODB_LAYER')) {
 
 		$this->_isPersistentConnection = true;
 
-		if ($rez = $this->_pconnect($this->host, $this->user, $argPassword, $this->database)) {
+		if ($rez = $this->_pconnect($this->host, $this->user, $this->password, $this->database)) {
 			return true;
 		}
 		if (isset($rez)) {
@@ -1146,6 +1146,11 @@ if (!defined('_ADODB_LAYER')) {
 	 * @return false|ADORecordSet
 	 */
 	public function Execute($sql, $inputarr = false) {
+
+		/* check if sill connected, otherwise reconnect to db */
+		if (!$this->_ping()) {
+			$this->PConnect();
+		}
 		if ($this->fnExecute) {
 			$fn = $this->fnExecute;
 			$ret = $fn($this,$sql,$inputarr);

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -788,6 +788,10 @@ class ADODB_mysqli extends ADOConnection {
 		return array($sql,$stmt);
 	}
 
+	/* check if connection is still alive */
+	function _ping() {
+		return mysqli_ping($this->_connectionID);
+	}
 
 	// returns queryID or false
 	function _query($sql, $inputarr)

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -475,6 +475,20 @@ class ADODB_pdo extends ADOConnection {
 		return parent::GenID($seqname, $startID);
 	}
 
+	/* check if connection is still alive */
+ 	function _ping() {
+   		$stmt = $this->_connectionID->prepare('SELECT 1');
+    		if ($stmt) {
+    			$ok = $stmt->execute();
+    			$stmt = false;
+    			if (!$ok) {
+    				return false;
+    			}
+    			return true;
+    		}
+    		return false;
+    	}
+
 
 	/* returns queryID or false */
 	function _query($sql,$inputarr=false)


### PR DESCRIPTION

Hello,

   I've added auto reconnect support for the mysqli and PDO drivers. I was having a lot of problems having mysql has gone away errors and this solves this problem.
   I think it be simple to implement for every other database.