### PR TITLE
Provide a method of creating compact trigger/sequence names, see #565

### DIFF
--- a/datadict/datadict-oci8.inc.php
+++ b/datadict/datadict-oci8.inc.php
@@ -26,11 +26,14 @@ class ADODB2_oci8 extends ADODB_DataDict {
 	var $typeX = 'VARCHAR(4000)';
 	var $typeXL = 'CLOB';
 	
-	/*
-	* Legacy compatibility for sequence names for emulated auto-increments
-	* If set to true, creates sequences and triggers as TRIG_394545594
-	* instead of TRIG_possibly_too_long_tablename
-	*/
+	/**
+	 * Legacy compatibility for sequence names for emulated auto-increments.
+	 *
+	 * If set to true, creates sequences and triggers as TRIG_394545594
+	 * instead of TRIG_possibly_too_long_tablename
+	 *
+	 * @var bool $useCompactAutoIncrements
+	 */
 	public $useCompactAutoIncrements = false;
 
 	function metaType($t, $len=-1, $fieldobj=false)
@@ -193,14 +196,14 @@ class ADODB2_oci8 extends ADODB_DataDict {
 	}
 
 	/**
-	* Creates an insert trigger to emulate an auto-increment column
-	* in a table
-	*
-	* @param	str		$tabname		The name of the table
-	* @param	str[]	$tableoptions   Optional configuration items
-	*
-	* @return	str[]	The SQL statements to create the trigger
-	*/
+	 * Creates an insert trigger to emulate an auto-increment column
+	 * in a table
+	 *
+	 * @param string   $tabname       The name of the table
+	 * @param string[] $tableoptions  Optional configuration items
+	 *
+	 * @return string[] The SQL statements to create the trigger
+	 */
 	function _Triggers($tabname,$tableoptions)
 	{
 		


### PR DESCRIPTION
This enhancement provides a method of creating an emulated auto-increment column for a table with a name greater than 25 characters, built using createTableSql() and specifying an "AUTO" option on the required column.

Instead of using the table name, a CRC32 value of the tablename is created and used for the name of the sequence and trigger, i.e. instead of a trigger called "TRIG_EMPLOYEES" for a table called "EMPLOYEES", it create a trigger "TRIG_3129131776", and similarly, a trigger for a table named "EMPLOYEE_HOURLY_PAY_RATES" becomes "TRIG_3754194288". The name of the trigger and sequence can be easily obtained after the fact by finding the CRC32 value of the table name.

The feature is provided with a compatibility flag that must be enabled. Existing configurations that already use this feature are unchanged. To activate, set the dictionary class variable $dict->useCompactAutoIncrements = true when building the table, and the connection class variable $db->useCompactAutoIncrements = true when using the table in ADOdb.

The feature is global for the database and cannot be specified on a table level basis.