### PR TITLE
Removal of useless PHP 4 and 5 version checks

### DIFF
--- a/adodb-active-record.inc.php
+++ b/adodb-active-record.inc.php
@@ -52,23 +52,23 @@ function ADODB_SetDatabaseAdapter(&$db, $index=false)
 {
 	global $_ADODB_ACTIVE_DBS;
 
-		foreach($_ADODB_ACTIVE_DBS as $k => $d) {
-			if($d->db === $db) {
-				return $k;
-			}
+	foreach($_ADODB_ACTIVE_DBS as $k => $d) {
+		if($d->db === $db) {
+			return $k;
 		}
+	}
 
-		$obj = new ADODB_Active_DB();
-		$obj->db = $db;
-		$obj->tables = array();
+	$obj = new ADODB_Active_DB();
+	$obj->db = $db;
+	$obj->tables = array();
 
-		if ($index == false) {
-			$index = sizeof($_ADODB_ACTIVE_DBS);
-		}
+	if ($index == false) {
+		$index = sizeof($_ADODB_ACTIVE_DBS);
+	}
 
-		$_ADODB_ACTIVE_DBS[$index] = $obj;
+	$_ADODB_ACTIVE_DBS[$index] = $obj;
 
-		return sizeof($_ADODB_ACTIVE_DBS)-1;
+	return sizeof($_ADODB_ACTIVE_DBS)-1;
 }
 
 

--- a/adodb-active-record.inc.php
+++ b/adodb-active-record.inc.php
@@ -53,14 +53,8 @@ function ADODB_SetDatabaseAdapter(&$db, $index=false)
 	global $_ADODB_ACTIVE_DBS;
 
 		foreach($_ADODB_ACTIVE_DBS as $k => $d) {
-			if (PHP_VERSION >= 5) {
-				if ($d->db === $db) {
-					return $k;
-				}
-			} else {
-				if ($d->db->_connectionID === $db->_connectionID && $db->database == $d->db->database) {
-					return $k;
-				}
+			if($d->db === $db) {
+				return $k;
 			}
 		}
 

--- a/adodb-active-recordx.inc.php
+++ b/adodb-active-recordx.inc.php
@@ -67,14 +67,8 @@ function ADODB_SetDatabaseAdapter(&$db)
 	global $_ADODB_ACTIVE_DBS;
 
 		foreach($_ADODB_ACTIVE_DBS as $k => $d) {
-			if (PHP_VERSION >= 5) {
-				if ($d->db === $db) {
-					return $k;
-				}
-			} else {
-				if ($d->db->_connectionID === $db->_connectionID && $db->database == $d->db->database) {
-					return $k;
-				}
+			if ($d->db === $db) {
+				return $k;
 			}
 		}
 

--- a/adodb-active-recordx.inc.php
+++ b/adodb-active-recordx.inc.php
@@ -66,19 +66,19 @@ function ADODB_SetDatabaseAdapter(&$db)
 {
 	global $_ADODB_ACTIVE_DBS;
 
-		foreach($_ADODB_ACTIVE_DBS as $k => $d) {
-			if ($d->db === $db) {
-				return $k;
-			}
+	foreach($_ADODB_ACTIVE_DBS as $k => $d) {
+		if ($d->db === $db) {
+			return $k;
 		}
+	}
 
-		$obj = new ADODB_Active_DB();
-		$obj->db = $db;
-		$obj->tables = array();
+	$obj = new ADODB_Active_DB();
+	$obj->db = $db;
+	$obj->tables = array();
 
-		$_ADODB_ACTIVE_DBS[] = $obj;
+	$_ADODB_ACTIVE_DBS[] = $obj;
 
-		return sizeof($_ADODB_ACTIVE_DBS)-1;
+	return sizeof($_ADODB_ACTIVE_DBS)-1;
 }
 
 

--- a/adodb-perf.inc.php
+++ b/adodb-perf.inc.php
@@ -266,12 +266,6 @@ processes 69293
 		// Algorithm is taken from
 		// http://social.technet.microsoft.com/Forums/en-US/winservergen/thread/414b0e1b-499c-411e-8a02-6a12e339c0f1/
 		if (strncmp(PHP_OS,'WIN',3)==0) {
-			if (PHP_VERSION == '5.0.0') return false;
-			if (PHP_VERSION == '5.0.1') return false;
-			if (PHP_VERSION == '5.0.2') return false;
-			if (PHP_VERSION == '5.0.3') return false;
-			if (PHP_VERSION == '4.3.10') return false; # see http://bugs.php.net/bug.php?id=31737
-
 			static $FAIL = false;
 			if ($FAIL) return false;
 

--- a/adodb-time.inc.php
+++ b/adodb-time.inc.php
@@ -404,8 +404,6 @@ First implementation.
 */
 define('ADODB_DATE_VERSION',0.35);
 
-$ADODB_DATETIME_CLASS = (PHP_VERSION >= 5.2);
-
 /*
 	This code was originally for windows. But apparently this problem happens
 	also with Linux, RH 7.3 and later!
@@ -737,13 +735,12 @@ function adodb_get_gmt_diff_ts($ts)
 */
 function adodb_get_gmt_diff($y,$m,$d)
 {
-static $TZ,$tzo;
-global $ADODB_DATETIME_CLASS;
+	static $TZ,$tzo;
 
 	if (!defined('ADODB_TEST_DATES')) $y = false;
 	else if ($y < 1970 || $y >= 2038) $y = false;
 
-	if ($ADODB_DATETIME_CLASS && $y !== false) {
+	if ($y !== false) {
 		$dt = new DateTime();
 		$dt->setISODate($y,$m,$d);
 		if (empty($tzo)) {
@@ -1081,9 +1078,8 @@ function adodb_date2($fmt, $d=false, $is_gmt=false)
 */
 function adodb_date($fmt,$d=false,$is_gmt=false)
 {
-static $daylight;
-global $ADODB_DATETIME_CLASS;
-static $jan1_1971;
+	static $daylight;
+	static $jan1_1971;
 
 	if (!isset($daylight)) {
 		$daylight = function_exists('adodb_daylight_sv');
@@ -1135,12 +1131,9 @@ static $jan1_1971;
 			$dates .= date('e');
 			break;
 		case 'T':
-			if ($ADODB_DATETIME_CLASS) {
-				$dt = new DateTime();
-				$dt->SetDate($year,$month,$day);
-				$dates .= $dt->Format('T');
-			} else
-				$dates .= date('T');
+			$dt = new DateTime();
+			$dt->SetDate($year,$month,$day);
+			$dates .= $dt->Format('T');
 			break;
 		// YEAR
 		case 'L': $dates .= $arr['leap'] ? '1' : '0'; break;

--- a/adodb-time.inc.php
+++ b/adodb-time.inc.php
@@ -1032,20 +1032,12 @@ global $_month_table_normal,$_month_table_leaf, $_adodb_last_date_call_failed;
 		0 => $origd
 	);
 }
-/*
-		if ($isphp5)
-				$dates .= sprintf('%s%04d',($gmt<=0)?'+':'-',abs($gmt)/36);
-			else
-				$dates .= sprintf('%s%04d',($gmt<0)?'+':'-',abs($gmt)/36);
-			break;*/
-function adodb_tz_offset($gmt,$isphp5)
+
+function adodb_tz_offset($gmt,$ignored=true)
 {
 	$zhrs = abs($gmt)/3600;
 	$hrs = floor($zhrs);
-	if ($isphp5)
-		return sprintf('%s%02d%02d',($gmt<=0)?'+':'-',floor($zhrs),($zhrs-$hrs)*60);
-	else
-		return sprintf('%s%02d%02d',($gmt<0)?'+':'-',floor($zhrs),($zhrs-$hrs)*60);
+	return sprintf('%s%02d%02d',($gmt<=0)?'+':'-',floor($zhrs),($zhrs-$hrs)*60);
 }
 
 
@@ -1119,8 +1111,6 @@ function adodb_date($fmt,$d=false,$is_gmt=false)
 	$max = strlen($fmt);
 	$dates = '';
 
-	$isphp5 = PHP_VERSION >= 5;
-
 	/*
 		at this point, we have the following integer vars to manipulate:
 		$year, $month, $day, $hour, $min, $secs
@@ -1152,7 +1142,7 @@ function adodb_date($fmt,$d=false,$is_gmt=false)
 
 			$gmt = adodb_get_gmt_diff($year,$month,$day);
 
-			$dates .= ' '.adodb_tz_offset($gmt,$isphp5);
+			$dates .= ' '.adodb_tz_offset($gmt);
 			break;
 
 		case 'Y': $dates .= $year; break;
@@ -1190,7 +1180,7 @@ function adodb_date($fmt,$d=false,$is_gmt=false)
 		case 'O':
 			$gmt = ($is_gmt) ? 0 : adodb_get_gmt_diff($year,$month,$day);
 
-			$dates .= adodb_tz_offset($gmt,$isphp5);
+			$dates .= adodb_tz_offset($gmt);
 			break;
 
 		case 'H':

--- a/adodb-time.inc.php
+++ b/adodb-time.inc.php
@@ -1033,6 +1033,14 @@ global $_month_table_normal,$_month_table_leaf, $_adodb_last_date_call_failed;
 	);
 }
 
+/**
+ * Compute timezone offset.
+ *
+ * @param int  $gmt     Time offset from GMT, in seconds
+ * @param bool $ignored Param leftover from removed PHP4-compatibility code
+ *                      kept to avoid altering function signature.
+ * @return string
+ */
 function adodb_tz_offset($gmt,$ignored=true)
 {
 	$zhrs = abs($gmt)/3600;

--- a/adodb-time.inc.php
+++ b/adodb-time.inc.php
@@ -1041,11 +1041,11 @@ global $_month_table_normal,$_month_table_leaf, $_adodb_last_date_call_failed;
  *                      kept to avoid altering function signature.
  * @return string
  */
-function adodb_tz_offset($gmt,$ignored=true)
+function adodb_tz_offset($gmt, $ignored=true)
 {
-	$zhrs = abs($gmt)/3600;
+	$zhrs = abs($gmt) / 3600;
 	$hrs = floor($zhrs);
-	return sprintf('%s%02d%02d',($gmt<=0)?'+':'-',floor($zhrs),($zhrs-$hrs)*60);
+	return sprintf('%s%02d%02d', ($gmt <= 0) ? '+' : '-', floor($zhrs), ($zhrs - $hrs) * 60);
 }
 
 

--- a/adodb-time.inc.php
+++ b/adodb-time.inc.php
@@ -1045,7 +1045,7 @@ function adodb_tz_offset($gmt, $ignored=true)
 {
 	$zhrs = abs($gmt) / 3600;
 	$hrs = floor($zhrs);
-	return sprintf('%s%02d%02d', ($gmt <= 0) ? '+' : '-', floor($zhrs), ($zhrs - $hrs) * 60);
+	return sprintf('%s%02d%02d', ($gmt <= 0) ? '+' : '-', $hrs, ($zhrs - $hrs) * 60);
 }
 
 

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -4436,11 +4436,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 			}
 		}
 		$i = 0;
-		if (PHP_VERSION >= 5) {
-			$o = clone($this->_obj);
-		} else {
-			$o = $this->_obj;
-		}
+		$o = clone($this->_obj);
 
 		for ($i=0; $i <$this->_numOfFields; $i++) {
 			$name = $this->_names[$i];
@@ -5013,9 +5009,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 		$db = strtolower($dbType);
 		switch ($db) {
 			case 'ado':
-				if (PHP_VERSION >= 5) {
-					$db = 'ado5';
-				}
+				$db = 'ado5';
 				$class = 'ado';
 				break;
 

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -178,18 +178,7 @@ if (!defined('_ADODB_LAYER')) {
 	define('DB_AUTOQUERY_UPDATE', 2);
 
 
-	// PHP's version scheme makes converting to numbers difficult - workaround
-	$_adodb_ver = (float) PHP_VERSION;
-	if ($_adodb_ver >= 5.2) {
-		define('ADODB_PHPVER',0x5200);
-	} else if ($_adodb_ver >= 5.0) {
-		define('ADODB_PHPVER',0x5000);
-	} else {
-		die("PHP5 or later required. You are running ".PHP_VERSION);
-	}
-	unset($_adodb_ver);
-
-
+	
 	function ADODB_Setup() {
 	GLOBAL
 		$ADODB_vers,		// database version

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,7 +33,7 @@ Older changelogs:
 - adodb: add control over BLOB data dictionary feature (NOT NULL, DEFAULT). #292, #478
 - adodb: fix field names quoting when setting value to null. #572
 - adodb: Remove unneeded ADODB_str_replace function. #582
-- adodb: Remove needless PHP4 version check. #583
+- adodb: Remove useless PHP 4 and 5 version checks. #583, #584
 - adodb: replace _array_change_key_case() by internal PHP function. #587
 - adodb-time: Fix 'Q' (quarter of year) format in adodb_date(). #222
 - adodb-time: Add 'W' (week of year) format support in adodb_date(). #223

--- a/drivers/adodb-access.inc.php
+++ b/drivers/adodb-access.inc.php
@@ -55,8 +55,6 @@ class  ADODB_access extends ADODB_odbc {
 		$ADODB_FETCH_MODE = $savem;
 		if (!$rs) return false;
 
-		$rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
-
 		$arr = $rs->GetArray();
 		//print_pre($arr);
 		$arr2 = array();

--- a/drivers/adodb-ado.inc.php
+++ b/drivers/adodb-ado.inc.php
@@ -52,9 +52,7 @@ class ADODB_ado extends ADOConnection {
 
 	function _affectedrows()
 	{
-		if (PHP_VERSION >= 5) return $this->_affectedRows;
-
-		return $this->_affectedRows->value;
+		return $this->_affectedRows;
 	}
 
 	// you can also pass a connection string like this:

--- a/drivers/adodb-ado5.inc.php
+++ b/drivers/adodb-ado5.inc.php
@@ -52,9 +52,7 @@ class ADODB_ado extends ADOConnection {
 
 	function _affectedrows()
 	{
-		if (PHP_VERSION >= 5) return $this->_affectedRows;
-
-		return $this->_affectedRows->value;
+		return $this->_affectedRows;
 	}
 
 	// you can also pass a connection string like this:

--- a/drivers/adodb-ado_access.inc.php
+++ b/drivers/adodb-ado_access.inc.php
@@ -17,8 +17,7 @@ Set tabs to 4 for best viewing.
 if (!defined('ADODB_DIR')) die();
 
 if (!defined('_ADODB_ADO_LAYER')) {
-	if (PHP_VERSION >= 5) include_once(ADODB_DIR."/drivers/adodb-ado5.inc.php");
-	else include_once(ADODB_DIR."/drivers/adodb-ado.inc.php");
+	include_once(ADODB_DIR . "/drivers/adodb-ado5.inc.php");
 }
 
 class  ADODB_ado_access extends ADODB_ado {

--- a/drivers/adodb-ado_mssql.inc.php
+++ b/drivers/adodb-ado_mssql.inc.php
@@ -21,8 +21,7 @@ Set tabs to 4 for best viewing.
 if (!defined('ADODB_DIR')) die();
 
 if (!defined('_ADODB_ADO_LAYER')) {
-	if (PHP_VERSION >= 5) include_once(ADODB_DIR."/drivers/adodb-ado5.inc.php");
-	else include_once(ADODB_DIR."/drivers/adodb-ado.inc.php");
+	include_once(ADODB_DIR . "/drivers/adodb-ado5.inc.php");
 }
 
 

--- a/drivers/adodb-ads.inc.php
+++ b/drivers/adodb-ads.inc.php
@@ -63,7 +63,6 @@ class ADODB_ads extends ADOConnection
 	var $curmode = SQL_CUR_USE_DRIVER; // See sqlext.h, SQL_CUR_DEFAULT == SQL_CUR_USE_DRIVER == 2L
 	var $_genSeqSQL = "create table %s (id integer)";
 	var $_autocommit = true;
-	var $_has_stupid_odbc_fetch_api_change = true;
 	var $_lastAffectedRows = 0;
 	var $uCaseTables = true; // for meta* functions, uppercase table names
 
@@ -419,7 +418,6 @@ class ADODB_ads extends ADOConnection
 		  $rs = new ADORecordSet_ads($qid2);
 		  $ADODB_FETCH_MODE = $savem;
 		  if (!$rs) return false;
-		  $rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
 		  $rs->_fetch();
 
 		  while (!$rs->EOF) {
@@ -464,7 +462,6 @@ class ADODB_ads extends ADOConnection
 		if (!$rs) {
 			return $false;
 		}
-		$rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
 		$rs->_fetch();
 
 		$retarr = array();
@@ -677,7 +674,6 @@ class ADORecordSet_ads extends ADORecordSet
 	var $databaseType = "ads";
 	var $dataProvider = "ads";
 	var $useFetchArray;
-	var $_has_stupid_odbc_fetch_api_change = true;
 
 	function __construct($id, $mode = false)
 	{
@@ -794,12 +790,7 @@ class ADORecordSet_ads extends ADORecordSet
 	function _fetch()
 	{
 		$this->fields = false;
-		if ($this->_has_stupid_odbc_fetch_api_change) {
-			$rez = @ads_fetch_into($this->_queryID, $this->fields);
-		} else {
-			$row = 0;
-			$rez = @ads_fetch_into($this->_queryID, $row, $this->fields);
-		}
+		$rez = @ads_fetch_into($this->_queryID, $this->fields);
 		if ($rez) {
 			if ($this->fetchMode & ADODB_FETCH_ASSOC) {
 				$this->fields =& $this->GetRowAssoc();

--- a/drivers/adodb-ads.inc.php
+++ b/drivers/adodb-ads.inc.php
@@ -65,9 +65,6 @@ class ADODB_ads extends ADOConnection {
   var $_lastAffectedRows = 0;
   var $uCaseTables = true; // for meta* functions, uppercase table names
   
-  public $_haserrorfunctions = true;
-  public $_has_stupid_odbc_fetch_api_change = true;
-
   function __construct() {}
 
   // returns true or false

--- a/drivers/adodb-ads.inc.php
+++ b/drivers/adodb-ads.inc.php
@@ -60,7 +60,6 @@ class ADODB_ads extends ADOConnection {
   var $curmode = SQL_CUR_USE_DRIVER; // See sqlext.h, SQL_CUR_DEFAULT == SQL_CUR_USE_DRIVER == 2L
   var $_genSeqSQL = "create table %s (id integer)";
   var $_autocommit = true;
-  var $_haserrorfunctions = true;
   var $_has_stupid_odbc_fetch_api_change = true;
   var $_lastAffectedRows = 0;
   var $uCaseTables = true; // for meta* functions, uppercase table names
@@ -182,18 +181,14 @@ class ADODB_ads extends ADOConnection {
 
   function ErrorMsg()
   {
-    if ($this->_haserrorfunctions) {
       if ($this->_errorMsg !== false) return $this->_errorMsg;
       if (empty($this->_connectionID)) return @ads_errormsg();
       return @ads_errormsg($this->_connectionID);
-    } else return ADOConnection::ErrorMsg();
   }
 
 
   function ErrorNo()
   {
-
-                if ($this->_haserrorfunctions) {
       if ($this->_errorCode !== false) {
         // bug in 4.0.6, error number can be corrupted string (should be 6 digits)
         return (strlen($this->_errorCode)<=2) ? 0 : $this->_errorCode;
@@ -206,7 +201,6 @@ class ADODB_ads extends ADOConnection {
        // so we check and patch
       if (strlen($e)<=2) return 0;
       return $e;
-    } else return ADOConnection::ErrorNo();
   }
 
 
@@ -526,10 +520,8 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
 
       if (! ads_execute($stmtid,$inputarr)) {
         //@ads_free_result($stmtid);
-        if ($this->_haserrorfunctions) {
-          $this->_errorMsg = ads_errormsg();
-          $this->_errorCode = ads_error();
-        }
+        $this->_errorMsg = ads_errormsg();
+        $this->_errorCode = ads_error();
         return false;
       }
 
@@ -537,10 +529,8 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
       $stmtid = $sql[1];
       if (!ads_execute($stmtid)) {
         //@ads_free_result($stmtid);
-        if ($this->_haserrorfunctions) {
-          $this->_errorMsg = ads_errormsg();
-          $this->_errorCode = ads_error();
-        }
+        $this->_errorMsg = ads_errormsg();
+        $this->_errorCode = ads_error();
         return false;
       }
     } else
@@ -566,19 +556,11 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
 
       }
 
-      if ($this->_haserrorfunctions) {
-        $this->_errorMsg = '';
-        $this->_errorCode = 0;
-      } else {
-          $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
-      }
+      $this->_errorMsg = '';
+      $this->_errorCode = 0;
     } else {
-      if ($this->_haserrorfunctions) {
-        $this->_errorMsg = ads_errormsg();
-        $this->_errorCode = ads_error();
-      } else {
-          $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
-      }
+      $this->_errorMsg = ads_errormsg();
+      $this->_errorCode = ads_error();
     }
 
     return $stmtid;
@@ -604,11 +586,9 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
                   return false;
           }
                 if (! ads_execute($stmtid,array($val),array(SQL_BINARY) )){
-                        if ($this->_haserrorfunctions){
-                                $this->_errorMsg = ads_errormsg();
+					$this->_errorMsg = ads_errormsg();
                     $this->_errorCode = ads_error();
-            }
-                        return false;
+                    return false;
            }
                  return TRUE;
         }

--- a/drivers/adodb-ads.inc.php
+++ b/drivers/adodb-ads.inc.php
@@ -64,13 +64,11 @@ class ADODB_ads extends ADOConnection {
   var $_has_stupid_odbc_fetch_api_change = true;
   var $_lastAffectedRows = 0;
   var $uCaseTables = true; // for meta* functions, uppercase table names
+  
+  public $_haserrorfunctions = true;
+  public $_has_stupid_odbc_fetch_api_change = true;
 
-
-  function __construct()
-  {
-    $this->_haserrorfunctions = ADODB_PHPVER >= 0x4050;
-    $this->_has_stupid_odbc_fetch_api_change = ADODB_PHPVER >= 0x4200;
-  }
+  function __construct(){}
 
   // returns true or false
   function _connect($argDSN, $argUsername, $argPassword, $argDatabasename)
@@ -114,19 +112,21 @@ class ADODB_ads extends ADOConnection {
   function ServerInfo()
   {
 
-    if (!empty($this->host) && ADODB_PHPVER >= 0x4300) {
-      $stmt = $this->Prepare('EXECUTE PROCEDURE sp_mgGetInstallInfo()');
-                        $res =  $this->Execute($stmt);
-                        if(!$res)
-                                print $this->ErrorMsg();
-                        else{
-                                $ret["version"]= $res->fields[3];
-                                $ret["description"]="Advantage Database Server";
-                                return $ret;
-                        }
-                }
-                else {
-            return ADOConnection::ServerInfo();
+    if (!empty($this->host))
+	{
+		$stmt = $this->Prepare('EXECUTE PROCEDURE sp_mgGetInstallInfo()');
+		$res =  $this->Execute($stmt);
+		if(!$res)
+			print $this->ErrorMsg();
+		else{
+			$ret["version"]= $res->fields[3];
+			$ret["description"]="Advantage Database Server";
+			return $ret;
+		}
+	}
+	else 
+	{
+		return ADOConnection::ServerInfo();
     }
   }
 

--- a/drivers/adodb-ads.inc.php
+++ b/drivers/adodb-ads.inc.php
@@ -68,7 +68,7 @@ class ADODB_ads extends ADOConnection {
   public $_haserrorfunctions = true;
   public $_has_stupid_odbc_fetch_api_change = true;
 
-  function __construct(){}
+  function __construct() {}
 
   // returns true or false
   function _connect($argDSN, $argUsername, $argPassword, $argDatabasename)
@@ -111,23 +111,20 @@ class ADODB_ads extends ADOConnection {
   // returns the Server version and Description
   function ServerInfo()
   {
-
-    if (!empty($this->host))
-	{
+	if (!empty($this->host)) {
 		$stmt = $this->Prepare('EXECUTE PROCEDURE sp_mgGetInstallInfo()');
 		$res =  $this->Execute($stmt);
-		if(!$res)
+		if (!$res) {
 			print $this->ErrorMsg();
-		else{
+		}
+		else {
 			$ret["version"]= $res->fields[3];
 			$ret["description"]="Advantage Database Server";
 			return $ret;
 		}
-	}
-	else 
-	{
+	} else {
 		return ADOConnection::ServerInfo();
-    }
+	}
   }
 
 

--- a/drivers/adodb-ads.inc.php
+++ b/drivers/adodb-ads.inc.php
@@ -638,7 +638,7 @@ class ADORecordSet_ads extends ADORecordSet {
   var $databaseType = "ads";
   var $dataProvider = "ads";
   var $useFetchArray;
-  var $_has_stupid_odbc_fetch_api_change;
+  var $_has_stupid_odbc_fetch_api_change = true;
 
   function __construct($id,$mode=false)
   {
@@ -696,7 +696,6 @@ class ADORecordSet_ads extends ADORecordSet {
     // some silly drivers such as db2 as/400 and intersystems cache return _numOfRows = 0
     if ($this->_numOfRows == 0) $this->_numOfRows = -1;
     //$this->useFetchArray = $this->connection->useFetchArray;
-    $this->_has_stupid_odbc_fetch_api_change = ADODB_PHPVER >= 0x4200;
   }
 
   function _seek($row)

--- a/drivers/adodb-ads.inc.php
+++ b/drivers/adodb-ads.inc.php
@@ -36,575 +36,633 @@ DELPHI FOR PHP USERS:
 
 */
 // security - hide paths
-if (!defined('ADODB_DIR')) die();
+if (!defined('ADODB_DIR')) {
+	die();
+}
 
-  define("_ADODB_ADS_LAYER", 2 );
+define("_ADODB_ADS_LAYER", 2);
 
 /*--------------------------------------------------------------------------------------
 --------------------------------------------------------------------------------------*/
 
 
-class ADODB_ads extends ADOConnection {
-  var $databaseType = "ads";
-  var $fmt = "'m-d-Y'";
-  var $fmtTimeStamp = "'Y-m-d H:i:s'";
-        var $concat_operator = '';
-  var $replaceQuote = "''"; // string to use to replace quotes
-  var $dataProvider = "ads";
-  var $hasAffectedRows = true;
-  var $binmode = ODBC_BINMODE_RETURN;
-  var $useFetchArray = false; // setting this to true will make array elements in FETCH_ASSOC mode case-sensitive
-                        // breaking backward-compat
-  //var $longreadlen = 8000; // default number of chars to return for a Blob/Long field
-  var $_bindInputArray = false;
-  var $curmode = SQL_CUR_USE_DRIVER; // See sqlext.h, SQL_CUR_DEFAULT == SQL_CUR_USE_DRIVER == 2L
-  var $_genSeqSQL = "create table %s (id integer)";
-  var $_autocommit = true;
-  var $_has_stupid_odbc_fetch_api_change = true;
-  var $_lastAffectedRows = 0;
-  var $uCaseTables = true; // for meta* functions, uppercase table names
-  
-  function __construct() {}
+class ADODB_ads extends ADOConnection
+{
+	var $databaseType = "ads";
+	var $fmt = "'m-d-Y'";
+	var $fmtTimeStamp = "'Y-m-d H:i:s'";
+	var $concat_operator = '';
+	var $replaceQuote = "''"; // string to use to replace quotes
+	var $dataProvider = "ads";
+	var $hasAffectedRows = true;
+	var $binmode = ODBC_BINMODE_RETURN;
+	var $useFetchArray = false; // setting this to true will make array elements in FETCH_ASSOC mode case-sensitive
+	// breaking backward-compat
+	//var $longreadlen = 8000; // default number of chars to return for a Blob/Long field
+	var $_bindInputArray = false;
+	var $curmode = SQL_CUR_USE_DRIVER; // See sqlext.h, SQL_CUR_DEFAULT == SQL_CUR_USE_DRIVER == 2L
+	var $_genSeqSQL = "create table %s (id integer)";
+	var $_autocommit = true;
+	var $_has_stupid_odbc_fetch_api_change = true;
+	var $_lastAffectedRows = 0;
+	var $uCaseTables = true; // for meta* functions, uppercase table names
 
-  // returns true or false
-  function _connect($argDSN, $argUsername, $argPassword, $argDatabasename)
-  {
-    if (!function_exists('ads_connect')) return null;
+	function __construct()
+	{
+	}
 
-    if ($this->debug && $argDatabasename && $this->databaseType != 'vfp') {
-      ADOConnection::outp("For Advantage Connect(), $argDatabasename is not used. Place dsn in 1st parameter.");
-    }
-    $last_php_error = $this->resetLastError();
-    if ($this->curmode === false) $this->_connectionID = ads_connect($argDSN,$argUsername,$argPassword);
-    else $this->_connectionID = ads_connect($argDSN,$argUsername,$argPassword,$this->curmode);
-    $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
-    if (isset($this->connectStmt)) $this->Execute($this->connectStmt);
+	// returns true or false
+	function _connect($argDSN, $argUsername, $argPassword, $argDatabasename)
+	{
+		if (!function_exists('ads_connect')) {
+			return null;
+		}
 
-    return $this->_connectionID != false;
-  }
+		if ($this->debug && $argDatabasename && $this->databaseType != 'vfp') {
+			ADOConnection::outp("For Advantage Connect(), $argDatabasename is not used. Place dsn in 1st parameter.");
+		}
+		$last_php_error = $this->resetLastError();
+		if ($this->curmode === false) {
+			$this->_connectionID = ads_connect($argDSN, $argUsername, $argPassword);
+		} else {
+			$this->_connectionID = ads_connect($argDSN, $argUsername, $argPassword, $this->curmode);
+		}
+		$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
+		if (isset($this->connectStmt)) {
+			$this->Execute($this->connectStmt);
+		}
 
-  // returns true or false
-  function _pconnect($argDSN, $argUsername, $argPassword, $argDatabasename)
-  {
-    if (!function_exists('ads_connect')) return null;
+		return $this->_connectionID != false;
+	}
 
-    $last_php_error = $this->resetLastError();
-    $this->_errorMsg = '';
-    if ($this->debug && $argDatabasename) {
-            ADOConnection::outp("For PConnect(), $argDatabasename is not used. Place dsn in 1st parameter.");
-    }
-  //  print "dsn=$argDSN u=$argUsername p=$argPassword<br>"; flush();
-    if ($this->curmode === false) $this->_connectionID = ads_connect($argDSN,$argUsername,$argPassword);
-    else $this->_connectionID = ads_pconnect($argDSN,$argUsername,$argPassword,$this->curmode);
+	// returns true or false
+	function _pconnect($argDSN, $argUsername, $argPassword, $argDatabasename)
+	{
+		if (!function_exists('ads_connect')) {
+			return null;
+		}
 
-    $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
-    if ($this->_connectionID && $this->autoRollback) @ads_rollback($this->_connectionID);
-    if (isset($this->connectStmt)) $this->Execute($this->connectStmt);
+		$last_php_error = $this->resetLastError();
+		$this->_errorMsg = '';
+		if ($this->debug && $argDatabasename) {
+			ADOConnection::outp("For PConnect(), $argDatabasename is not used. Place dsn in 1st parameter.");
+		}
+		//  print "dsn=$argDSN u=$argUsername p=$argPassword<br>"; flush();
+		if ($this->curmode === false) {
+			$this->_connectionID = ads_connect($argDSN, $argUsername, $argPassword);
+		} else {
+			$this->_connectionID = ads_pconnect($argDSN, $argUsername, $argPassword, $this->curmode);
+		}
 
-    return $this->_connectionID != false;
-  }
+		$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
+		if ($this->_connectionID && $this->autoRollback) {
+			@ads_rollback($this->_connectionID);
+		}
+		if (isset($this->connectStmt)) {
+			$this->Execute($this->connectStmt);
+		}
 
-  // returns the Server version and Description
-  function ServerInfo()
-  {
-	if (!empty($this->host)) {
-		$stmt = $this->Prepare('EXECUTE PROCEDURE sp_mgGetInstallInfo()');
-		$res =  $this->Execute($stmt);
+		return $this->_connectionID != false;
+	}
+
+	// returns the Server version and Description
+	function ServerInfo()
+	{
+
+		if (!empty($this->host)) {
+			$stmt = $this->Prepare('EXECUTE PROCEDURE sp_mgGetInstallInfo()');
+			$res = $this->Execute($stmt);
+			if (!$res) {
+				print $this->ErrorMsg();
+			} else {
+				$ret["version"] = $res->fields[3];
+				$ret["description"] = "Advantage Database Server";
+				return $ret;
+			}
+		} else {
+			return ADOConnection::ServerInfo();
+		}
+	}
+
+
+	// returns true or false
+	function CreateSequence($seqname = 'adodbseq', $start = 1)
+	{
+		$res = $this->Execute("CREATE TABLE $seqname ( ID autoinc( 1 ) ) IN DATABASE");
 		if (!$res) {
 			print $this->ErrorMsg();
+			return false;
+		} else {
+			return true;
 		}
-		else {
-			$ret["version"]= $res->fields[3];
-			$ret["description"]="Advantage Database Server";
+
+	}
+
+	// returns true or false
+	function DropSequence($seqname = 'adodbseq')
+	{
+		$res = $this->Execute("DROP TABLE $seqname");
+		if (!$res) {
+			print $this->ErrorMsg();
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+
+	// returns the generated ID or false
+	// checks if the table already exists, else creates the table and inserts a record into the table
+	// and gets the ID number of the last inserted record.
+	function GenID($seqname = 'adodbseq', $start = 1)
+	{
+		$go = $this->Execute("select * from $seqname");
+		if (!$go) {
+			$res = $this->Execute("CREATE TABLE $seqname ( ID autoinc( 1 ) ) IN DATABASE");
+			if (!$res) {
+				print $this->ErrorMsg();
+				return false;
+			}
+		}
+		$res = $this->Execute("INSERT INTO $seqname VALUES( DEFAULT )");
+		if (!$res) {
+			print $this->ErrorMsg();
+			return false;
+		} else {
+			$gen = $this->Execute("SELECT LastAutoInc( STATEMENT ) FROM system.iota");
+			$ret = $gen->fields[0];
 			return $ret;
 		}
-	} else {
-		return ADOConnection::ServerInfo();
+
 	}
-  }
-
-
-        // returns true or false
-        function CreateSequence($seqname = 'adodbseq', $start = 1)
-  {
-                $res =  $this->Execute("CREATE TABLE $seqname ( ID autoinc( 1 ) ) IN DATABASE");
-                if(!$res){
-                        print $this->ErrorMsg();
-                        return false;
-                }
-                else
-                        return true;
-
-        }
-
-        // returns true or false
-        function DropSequence($seqname = 'adodbseq')
-  {
-                $res = $this->Execute("DROP TABLE $seqname");
-                if(!$res){
-                        print $this->ErrorMsg();
-                        return false;
-                }
-                else
-                        return true;
-        }
-
-
-  // returns the generated ID or false
-        // checks if the table already exists, else creates the table and inserts a record into the table
-        // and gets the ID number of the last inserted record.
-        function GenID($seqname = 'adodbseq', $start = 1)
-        {
-                $go = $this->Execute("select * from $seqname");
-                if (!$go){
-                        $res = $this->Execute("CREATE TABLE $seqname ( ID autoinc( 1 ) ) IN DATABASE");
-                        if(!$res){
-                                print $this->ErrorMsg();
-                                return false;
-                        }
-                }
-                $res = $this->Execute("INSERT INTO $seqname VALUES( DEFAULT )");
-                if(!$res){
-                        print $this->ErrorMsg();
-                        return false;
-                }
-                else{
-                        $gen = $this->Execute("SELECT LastAutoInc( STATEMENT ) FROM system.iota");
-                        $ret = $gen->fields[0];
-                        return $ret;
-                }
-
-        }
-
-
-
-
-  function ErrorMsg()
-  {
-      if ($this->_errorMsg !== false) return $this->_errorMsg;
-      if (empty($this->_connectionID)) return @ads_errormsg();
-      return @ads_errormsg($this->_connectionID);
-  }
-
-
-  function ErrorNo()
-  {
-      if ($this->_errorCode !== false) {
-        // bug in 4.0.6, error number can be corrupted string (should be 6 digits)
-        return (strlen($this->_errorCode)<=2) ? 0 : $this->_errorCode;
-      }
-
-      if (empty($this->_connectionID)) $e = @ads_error();
-      else $e = @ads_error($this->_connectionID);
-
-       // bug in 4.0.6, error number can be corrupted string (should be 6 digits)
-       // so we check and patch
-      if (strlen($e)<=2) return 0;
-      return $e;
-  }
-
-
-
-  function BeginTrans()
-  {
-    if (!$this->hasTransactions) return false;
-    if ($this->transOff) return true;
-    $this->transCnt += 1;
-    $this->_autocommit = false;
-    return ads_autocommit($this->_connectionID,false);
-  }
-
-  function CommitTrans($ok=true)
-  {
-    if ($this->transOff) return true;
-    if (!$ok) return $this->RollbackTrans();
-    if ($this->transCnt) $this->transCnt -= 1;
-    $this->_autocommit = true;
-    $ret = ads_commit($this->_connectionID);
-    ads_autocommit($this->_connectionID,true);
-    return $ret;
-  }
-
-  function RollbackTrans()
-  {
-    if ($this->transOff) return true;
-    if ($this->transCnt) $this->transCnt -= 1;
-    $this->_autocommit = true;
-    $ret = ads_rollback($this->_connectionID);
-    ads_autocommit($this->_connectionID,true);
-    return $ret;
-  }
-
-
-  // Returns tables,Views or both on successful execution. Returns
-        // tables by default on successful execution.
-  function &MetaTables($ttype = false, $showSchema = false, $mask = false)
-  {
-          $recordSet1 = $this->Execute("select * from system.tables");
-                if(!$recordSet1){
-                        print $this->ErrorMsg();
-                        return false;
-                }
-                $recordSet2 = $this->Execute("select * from system.views");
-                if(!$recordSet2){
-                        print $this->ErrorMsg();
-                        return false;
-                }
-                $i=0;
-                while (!$recordSet1->EOF){
-                                 $arr["$i"] = $recordSet1->fields[0];
-                                 $recordSet1->MoveNext();
-                                 $i=$i+1;
-                }
-                if($ttype=='FALSE'){
-                        while (!$recordSet2->EOF){
-                                $arr["$i"] = $recordSet2->fields[0];
-                                $recordSet2->MoveNext();
-                                $i=$i+1;
-                        }
-                        return $arr;
-                }
-                elseif($ttype=='VIEWS'){
-                        while (!$recordSet2->EOF){
-                                $arrV["$i"] = $recordSet2->fields[0];
-                                $recordSet2->MoveNext();
-                                $i=$i+1;
-                        }
-                        return $arrV;
-                }
-                else{
-                        return $arr;
-                }
-
-  }
-
-        function &MetaPrimaryKeys($table, $owner = false)
-  {
-          $recordSet = $this->Execute("select table_primary_key from system.tables where name='$table'");
-                if(!$recordSet){
-                        print $this->ErrorMsg();
-                        return false;
-                }
-                $i=0;
-                while (!$recordSet->EOF){
-                                 $arr["$i"] = $recordSet->fields[0];
-                                 $recordSet->MoveNext();
-                                 $i=$i+1;
-                }
-                return $arr;
-        }
-
-/*
-See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/odbcdatetime_data_type_changes.asp
-/ SQL data type codes /
-#define SQL_UNKNOWN_TYPE  0
-#define SQL_CHAR      1
-#define SQL_NUMERIC    2
-#define SQL_DECIMAL    3
-#define SQL_INTEGER    4
-#define SQL_SMALLINT    5
-#define SQL_FLOAT      6
-#define SQL_REAL      7
-#define SQL_DOUBLE      8
-#if (ODBCVER >= 0x0300)
-#define SQL_DATETIME    9
-#endif
-#define SQL_VARCHAR   12
-
-
-/ One-parameter shortcuts for date/time data types /
-#if (ODBCVER >= 0x0300)
-#define SQL_TYPE_DATE   91
-#define SQL_TYPE_TIME   92
-#define SQL_TYPE_TIMESTAMP 93
-
-#define SQL_UNICODE                             (-95)
-#define SQL_UNICODE_VARCHAR                     (-96)
-#define SQL_UNICODE_LONGVARCHAR                 (-97)
-*/
-  function ODBCTypes($t)
-  {
-    switch ((integer)$t) {
-    case 1:
-    case 12:
-    case 0:
-    case -95:
-    case -96:
-      return 'C';
-    case -97:
-    case -1: //text
-      return 'X';
-    case -4: //image
-      return 'B';
-
-    case 9:
-    case 91:
-      return 'D';
-
-    case 10:
-    case 11:
-    case 92:
-    case 93:
-      return 'T';
-
-    case 4:
-    case 5:
-    case -6:
-      return 'I';
-
-    case -11: // uniqidentifier
-      return 'R';
-    case -7: //bit
-      return 'L';
-
-    default:
-      return 'N';
-    }
-  }
-
-  function &MetaColumns($table, $normalize = true)
-  {
-  global $ADODB_FETCH_MODE;
-
-    $false = false;
-    if ($this->uCaseTables) $table = strtoupper($table);
-    $schema = '';
-    $this->_findschema($table,$schema);
-
-    $savem = $ADODB_FETCH_MODE;
-    $ADODB_FETCH_MODE = ADODB_FETCH_NUM;
-
-    /*if (false) { // after testing, confirmed that the following does not work because of a bug
-      $qid2 = ads_tables($this->_connectionID);
-      $rs = new ADORecordSet_ads($qid2);
-      $ADODB_FETCH_MODE = $savem;
-      if (!$rs) return false;
-      $rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
-      $rs->_fetch();
-
-      while (!$rs->EOF) {
-        if ($table == strtoupper($rs->fields[2])) {
-          $q = $rs->fields[0];
-          $o = $rs->fields[1];
-          break;
-        }
-        $rs->MoveNext();
-      }
-      $rs->Close();
-
-      $qid = ads_columns($this->_connectionID,$q,$o,strtoupper($table),'%');
-    } */
-
-    switch ($this->databaseType) {
-    case 'access':
-    case 'vfp':
-      $qid = ads_columns($this->_connectionID);#,'%','',strtoupper($table),'%');
-      break;
-
-
-    case 'db2':
-            $colname = "%";
-            $qid = ads_columns($this->_connectionID, "", $schema, $table, $colname);
-            break;
-
-    default:
-      $qid = @ads_columns($this->_connectionID,'%','%',strtoupper($table),'%');
-      if (empty($qid)) $qid = ads_columns($this->_connectionID);
-      break;
-    }
-    if (empty($qid)) return $false;
-
-    $rs = new ADORecordSet_ads($qid);
-    $ADODB_FETCH_MODE = $savem;
-
-    if (!$rs) return $false;
-    $rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
-    $rs->_fetch();
-
-    $retarr = array();
-
-    /*
-    $rs->fields indices
-    0 TABLE_QUALIFIER
-    1 TABLE_SCHEM
-    2 TABLE_NAME
-    3 COLUMN_NAME
-    4 DATA_TYPE
-    5 TYPE_NAME
-    6 PRECISION
-    7 LENGTH
-    8 SCALE
-    9 RADIX
-    10 NULLABLE
-    11 REMARKS
-    */
-    while (!$rs->EOF) {
-    //  adodb_pr($rs->fields);
-      if (strtoupper(trim($rs->fields[2])) == $table && (!$schema || strtoupper($rs->fields[1]) == $schema)) {
-        $fld = new ADOFieldObject();
-        $fld->name = $rs->fields[3];
-        $fld->type = $this->ODBCTypes($rs->fields[4]);
-
-        // ref: http://msdn.microsoft.com/library/default.asp?url=/archive/en-us/dnaraccgen/html/msdn_odk.asp
-        // access uses precision to store length for char/varchar
-        if ($fld->type == 'C' or $fld->type == 'X') {
-          if ($this->databaseType == 'access')
-            $fld->max_length = $rs->fields[6];
-          else if ($rs->fields[4] <= -95) // UNICODE
-            $fld->max_length = $rs->fields[7]/2;
-          else
-            $fld->max_length = $rs->fields[7];
-        } else
-          $fld->max_length = $rs->fields[7];
-        $fld->not_null = !empty($rs->fields[10]);
-        $fld->scale = $rs->fields[8];
-        $retarr[strtoupper($fld->name)] = $fld;
-      } else if (sizeof($retarr)>0)
-        break;
-      $rs->MoveNext();
-    }
-    $rs->Close(); //-- crashes 4.03pl1 -- why?
-
-    if (empty($retarr)) $retarr = false;
-    return $retarr;
-  }
-
-        // Returns an array of columns names for a given table
-        function &MetaColumnNames($table, $numIndexes = false, $useattnum = false)
-        {
-                $recordSet = $this->Execute("select name from system.columns where parent='$table'");
-                if(!$recordSet){
-                        print $this->ErrorMsg();
-                        return false;
-                }
-                else{
-                        $i=0;
-                        while (!$recordSet->EOF){
-                                $arr["FIELD$i"] = $recordSet->fields[0];
-                                $recordSet->MoveNext();
-                                $i=$i+1;
-                        }
-                        return $arr;
-                }
-        }
-
-
-  function Prepare($sql)
-  {
-    if (! $this->_bindInputArray) return $sql; // no binding
-    $stmt = ads_prepare($this->_connectionID,$sql);
-    if (!$stmt) {
-      // we don't know whether odbc driver is parsing prepared stmts, so just return sql
-      return $sql;
-    }
-    return array($sql,$stmt,false);
-  }
-
-  /* returns queryID or false */
-  function _query($sql,$inputarr=false)
-  {
-    $last_php_error = $this->resetLastError();
-    $this->_errorMsg = '';
-
-                if ($inputarr) {
-      if (is_array($sql)) {
-        $stmtid = $sql[1];
-      } else {
-        $stmtid = ads_prepare($this->_connectionID,$sql);
-
-        if ($stmtid == false) {
-          $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
-          return false;
-        }
-      }
-
-      if (! ads_execute($stmtid,$inputarr)) {
-        //@ads_free_result($stmtid);
-        $this->_errorMsg = ads_errormsg();
-        $this->_errorCode = ads_error();
-        return false;
-      }
-
-    } else if (is_array($sql)) {
-      $stmtid = $sql[1];
-      if (!ads_execute($stmtid)) {
-        //@ads_free_result($stmtid);
-        $this->_errorMsg = ads_errormsg();
-        $this->_errorCode = ads_error();
-        return false;
-      }
-    } else
-                        {
-
-      $stmtid = ads_exec($this->_connectionID,$sql);
-
-                        }
-
-                $this->_lastAffectedRows = 0;
-
-    if ($stmtid) {
-
-      if (@ads_num_fields($stmtid) == 0) {
-        $this->_lastAffectedRows = ads_num_rows($stmtid);
-        $stmtid = true;
-
-      } else {
-
-        $this->_lastAffectedRows = 0;
-        ads_binmode($stmtid,$this->binmode);
-        ads_longreadlen($stmtid,$this->maxblobsize);
-
-      }
-
-      $this->_errorMsg = '';
-      $this->_errorCode = 0;
-    } else {
-      $this->_errorMsg = ads_errormsg();
-      $this->_errorCode = ads_error();
-    }
-
-    return $stmtid;
-
-  }
-
-  /*
-    Insert a null into the blob field of the table first.
-    Then use UpdateBlob to store the blob.
-
-    Usage:
-
-    $conn->Execute('INSERT INTO blobtable (id, blobcol) VALUES (1, null)');
-    $conn->UpdateBlob('blobtable','blobcol',$blob,'id=1');
-   */
-  function UpdateBlob($table,$column,$val,$where,$blobtype='BLOB')
-  {
-                $last_php_error = $this->resetLastError();
-                $sql = "UPDATE $table SET $column=? WHERE $where";
-                $stmtid = ads_prepare($this->_connectionID,$sql);
-                if ($stmtid == false){
-                  $this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
-                  return false;
-          }
-                if (! ads_execute($stmtid,array($val),array(SQL_BINARY) )){
+
+
+	function ErrorMsg()
+	{
+		if ($this->_errorMsg !== false) {
+			return $this->_errorMsg;
+		}
+		if (empty($this->_connectionID)) {
+			return @ads_errormsg();
+		}
+		return @ads_errormsg($this->_connectionID);
+	}
+
+
+	function ErrorNo()
+	{
+		if ($this->_errorCode !== false) {
+			// bug in 4.0.6, error number can be corrupted string (should be 6 digits)
+			return (strlen($this->_errorCode) <= 2) ? 0 : $this->_errorCode;
+		}
+
+		if (empty($this->_connectionID)) {
+			$e = @ads_error();
+		} else {
+			$e = @ads_error($this->_connectionID);
+		}
+
+		// bug in 4.0.6, error number can be corrupted string (should be 6 digits)
+		// so we check and patch
+		if (strlen($e) <= 2) {
+			return 0;
+		}
+		return $e;
+	}
+
+
+	function BeginTrans()
+	{
+		if (!$this->hasTransactions) {
+			return false;
+		}
+		if ($this->transOff) {
+			return true;
+		}
+		$this->transCnt += 1;
+		$this->_autocommit = false;
+		return ads_autocommit($this->_connectionID, false);
+	}
+
+	function CommitTrans($ok = true)
+	{
+		if ($this->transOff) {
+			return true;
+		}
+		if (!$ok) {
+			return $this->RollbackTrans();
+		}
+		if ($this->transCnt) {
+			$this->transCnt -= 1;
+		}
+		$this->_autocommit = true;
+		$ret = ads_commit($this->_connectionID);
+		ads_autocommit($this->_connectionID, true);
+		return $ret;
+	}
+
+	function RollbackTrans()
+	{
+		if ($this->transOff) {
+			return true;
+		}
+		if ($this->transCnt) {
+			$this->transCnt -= 1;
+		}
+		$this->_autocommit = true;
+		$ret = ads_rollback($this->_connectionID);
+		ads_autocommit($this->_connectionID, true);
+		return $ret;
+	}
+
+
+	// Returns tables,Views or both on successful execution. Returns
+	// tables by default on successful execution.
+	function &MetaTables($ttype = false, $showSchema = false, $mask = false)
+	{
+		$recordSet1 = $this->Execute("select * from system.tables");
+		if (!$recordSet1) {
+			print $this->ErrorMsg();
+			return false;
+		}
+		$recordSet2 = $this->Execute("select * from system.views");
+		if (!$recordSet2) {
+			print $this->ErrorMsg();
+			return false;
+		}
+		$i = 0;
+		while (!$recordSet1->EOF) {
+			$arr["$i"] = $recordSet1->fields[0];
+			$recordSet1->MoveNext();
+			$i = $i + 1;
+		}
+		if ($ttype == 'FALSE') {
+			while (!$recordSet2->EOF) {
+				$arr["$i"] = $recordSet2->fields[0];
+				$recordSet2->MoveNext();
+				$i = $i + 1;
+			}
+			return $arr;
+		} elseif ($ttype == 'VIEWS') {
+			while (!$recordSet2->EOF) {
+				$arrV["$i"] = $recordSet2->fields[0];
+				$recordSet2->MoveNext();
+				$i = $i + 1;
+			}
+			return $arrV;
+		} else {
+			return $arr;
+		}
+
+	}
+
+	function &MetaPrimaryKeys($table, $owner = false)
+	{
+		$recordSet = $this->Execute("select table_primary_key from system.tables where name='$table'");
+		if (!$recordSet) {
+			print $this->ErrorMsg();
+			return false;
+		}
+		$i = 0;
+		while (!$recordSet->EOF) {
+			$arr["$i"] = $recordSet->fields[0];
+			$recordSet->MoveNext();
+			$i = $i + 1;
+		}
+		return $arr;
+	}
+
+	/*
+	See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/odbcdatetime_data_type_changes.asp
+	/ SQL data type codes /
+	#define SQL_UNKNOWN_TYPE  0
+	#define SQL_CHAR      1
+	#define SQL_NUMERIC    2
+	#define SQL_DECIMAL    3
+	#define SQL_INTEGER    4
+	#define SQL_SMALLINT    5
+	#define SQL_FLOAT      6
+	#define SQL_REAL      7
+	#define SQL_DOUBLE      8
+	#if (ODBCVER >= 0x0300)
+	#define SQL_DATETIME    9
+	#endif
+	#define SQL_VARCHAR   12
+
+
+	/ One-parameter shortcuts for date/time data types /
+	#if (ODBCVER >= 0x0300)
+	#define SQL_TYPE_DATE   91
+	#define SQL_TYPE_TIME   92
+	#define SQL_TYPE_TIMESTAMP 93
+
+	#define SQL_UNICODE                             (-95)
+	#define SQL_UNICODE_VARCHAR                     (-96)
+	#define SQL_UNICODE_LONGVARCHAR                 (-97)
+	*/
+	function ODBCTypes($t)
+	{
+		switch ((integer)$t) {
+			case 1:
+			case 12:
+			case 0:
+			case -95:
+			case -96:
+				return 'C';
+			case -97:
+			case -1: //text
+				return 'X';
+			case -4: //image
+				return 'B';
+
+			case 9:
+			case 91:
+				return 'D';
+
+			case 10:
+			case 11:
+			case 92:
+			case 93:
+				return 'T';
+
+			case 4:
+			case 5:
+			case -6:
+				return 'I';
+
+			case -11: // uniqidentifier
+				return 'R';
+			case -7: //bit
+				return 'L';
+
+			default:
+				return 'N';
+		}
+	}
+
+	function &MetaColumns($table, $normalize = true)
+	{
+		global $ADODB_FETCH_MODE;
+
+		$false = false;
+		if ($this->uCaseTables) {
+			$table = strtoupper($table);
+		}
+		$schema = '';
+		$this->_findschema($table, $schema);
+
+		$savem = $ADODB_FETCH_MODE;
+		$ADODB_FETCH_MODE = ADODB_FETCH_NUM;
+
+		/*if (false) { // after testing, confirmed that the following does not work because of a bug
+		  $qid2 = ads_tables($this->_connectionID);
+		  $rs = new ADORecordSet_ads($qid2);
+		  $ADODB_FETCH_MODE = $savem;
+		  if (!$rs) return false;
+		  $rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
+		  $rs->_fetch();
+
+		  while (!$rs->EOF) {
+			if ($table == strtoupper($rs->fields[2])) {
+			  $q = $rs->fields[0];
+			  $o = $rs->fields[1];
+			  break;
+			}
+			$rs->MoveNext();
+		  }
+		  $rs->Close();
+
+		  $qid = ads_columns($this->_connectionID,$q,$o,strtoupper($table),'%');
+		} */
+
+		switch ($this->databaseType) {
+			case 'access':
+			case 'vfp':
+				$qid = ads_columns($this->_connectionID);#,'%','',strtoupper($table),'%');
+				break;
+
+
+			case 'db2':
+				$colname = "%";
+				$qid = ads_columns($this->_connectionID, "", $schema, $table, $colname);
+				break;
+
+			default:
+				$qid = @ads_columns($this->_connectionID, '%', '%', strtoupper($table), '%');
+				if (empty($qid)) {
+					$qid = ads_columns($this->_connectionID);
+				}
+				break;
+		}
+		if (empty($qid)) {
+			return $false;
+		}
+
+		$rs = new ADORecordSet_ads($qid);
+		$ADODB_FETCH_MODE = $savem;
+
+		if (!$rs) {
+			return $false;
+		}
+		$rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
+		$rs->_fetch();
+
+		$retarr = array();
+
+		/*
+		$rs->fields indices
+		0 TABLE_QUALIFIER
+		1 TABLE_SCHEM
+		2 TABLE_NAME
+		3 COLUMN_NAME
+		4 DATA_TYPE
+		5 TYPE_NAME
+		6 PRECISION
+		7 LENGTH
+		8 SCALE
+		9 RADIX
+		10 NULLABLE
+		11 REMARKS
+		*/
+		while (!$rs->EOF) {
+			//  adodb_pr($rs->fields);
+			if (strtoupper(trim($rs->fields[2])) == $table && (!$schema || strtoupper($rs->fields[1]) == $schema)) {
+				$fld = new ADOFieldObject();
+				$fld->name = $rs->fields[3];
+				$fld->type = $this->ODBCTypes($rs->fields[4]);
+
+				// ref: http://msdn.microsoft.com/library/default.asp?url=/archive/en-us/dnaraccgen/html/msdn_odk.asp
+				// access uses precision to store length for char/varchar
+				if ($fld->type == 'C' or $fld->type == 'X') {
+					if ($this->databaseType == 'access') {
+						$fld->max_length = $rs->fields[6];
+					} else {
+						if ($rs->fields[4] <= -95) // UNICODE
+						{
+							$fld->max_length = $rs->fields[7] / 2;
+						} else {
+							$fld->max_length = $rs->fields[7];
+						}
+					}
+				} else {
+					$fld->max_length = $rs->fields[7];
+				}
+				$fld->not_null = !empty($rs->fields[10]);
+				$fld->scale = $rs->fields[8];
+				$retarr[strtoupper($fld->name)] = $fld;
+			} else {
+				if (sizeof($retarr) > 0) {
+					break;
+				}
+			}
+			$rs->MoveNext();
+		}
+		$rs->Close(); //-- crashes 4.03pl1 -- why?
+
+		if (empty($retarr)) {
+			$retarr = false;
+		}
+		return $retarr;
+	}
+
+	// Returns an array of columns names for a given table
+	function &MetaColumnNames($table, $numIndexes = false, $useattnum = false)
+	{
+		$recordSet = $this->Execute("select name from system.columns where parent='$table'");
+		if (!$recordSet) {
+			print $this->ErrorMsg();
+			return false;
+		} else {
+			$i = 0;
+			while (!$recordSet->EOF) {
+				$arr["FIELD$i"] = $recordSet->fields[0];
+				$recordSet->MoveNext();
+				$i = $i + 1;
+			}
+			return $arr;
+		}
+	}
+
+
+	function Prepare($sql)
+	{
+		if (!$this->_bindInputArray) {
+			return $sql;
+		} // no binding
+		$stmt = ads_prepare($this->_connectionID, $sql);
+		if (!$stmt) {
+			// we don't know whether odbc driver is parsing prepared stmts, so just return sql
+			return $sql;
+		}
+		return array($sql, $stmt, false);
+	}
+
+	/* returns queryID or false */
+	function _query($sql, $inputarr = false)
+	{
+		$last_php_error = $this->resetLastError();
+		$this->_errorMsg = '';
+
+		if ($inputarr) {
+			if (is_array($sql)) {
+				$stmtid = $sql[1];
+			} else {
+				$stmtid = ads_prepare($this->_connectionID, $sql);
+
+				if ($stmtid == false) {
+					$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
+					return false;
+				}
+			}
+
+			if (!ads_execute($stmtid, $inputarr)) {
+				//@ads_free_result($stmtid);
+				$this->_errorMsg = ads_errormsg();
+				$this->_errorCode = ads_error();
+				return false;
+			}
+
+		} else {
+			if (is_array($sql)) {
+				$stmtid = $sql[1];
+				if (!ads_execute($stmtid)) {
+					//@ads_free_result($stmtid);
 					$this->_errorMsg = ads_errormsg();
-                    $this->_errorCode = ads_error();
-                    return false;
-           }
-                 return TRUE;
-        }
+					$this->_errorCode = ads_error();
+					return false;
+				}
+			} else {
 
-  // returns true or false
-  function _close()
-  {
-    $ret = @ads_close($this->_connectionID);
-    $this->_connectionID = false;
-    return $ret;
-  }
+				$stmtid = ads_exec($this->_connectionID, $sql);
 
-  function _affectedrows()
-  {
-    return $this->_lastAffectedRows;
-  }
+			}
+		}
+
+		$this->_lastAffectedRows = 0;
+
+		if ($stmtid) {
+
+			if (@ads_num_fields($stmtid) == 0) {
+				$this->_lastAffectedRows = ads_num_rows($stmtid);
+				$stmtid = true;
+
+			} else {
+
+				$this->_lastAffectedRows = 0;
+				ads_binmode($stmtid, $this->binmode);
+				ads_longreadlen($stmtid, $this->maxblobsize);
+
+			}
+
+			$this->_errorMsg = '';
+			$this->_errorCode = 0;
+		} else {
+			$this->_errorMsg = ads_errormsg();
+			$this->_errorCode = ads_error();
+		}
+
+		return $stmtid;
+
+	}
+
+	/*
+	  Insert a null into the blob field of the table first.
+	  Then use UpdateBlob to store the blob.
+
+	  Usage:
+
+	  $conn->Execute('INSERT INTO blobtable (id, blobcol) VALUES (1, null)');
+	  $conn->UpdateBlob('blobtable','blobcol',$blob,'id=1');
+	 */
+	function UpdateBlob($table, $column, $val, $where, $blobtype = 'BLOB')
+	{
+		$last_php_error = $this->resetLastError();
+		$sql = "UPDATE $table SET $column=? WHERE $where";
+		$stmtid = ads_prepare($this->_connectionID, $sql);
+		if ($stmtid == false) {
+			$this->_errorMsg = $this->getChangedErrorMsg($last_php_error);
+			return false;
+		}
+		if (!ads_execute($stmtid, array($val), array(SQL_BINARY))) {
+			$this->_errorMsg = ads_errormsg();
+			$this->_errorCode = ads_error();
+			return false;
+		}
+		return true;
+	}
+
+	// returns true or false
+	function _close()
+	{
+		$ret = @ads_close($this->_connectionID);
+		$this->_connectionID = false;
+		return $ret;
+	}
+
+	function _affectedrows()
+	{
+		return $this->_lastAffectedRows;
+	}
 
 }
 
@@ -612,138 +670,148 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
    Class Name: Recordset
 --------------------------------------------------------------------------------------*/
 
-class ADORecordSet_ads extends ADORecordSet {
+class ADORecordSet_ads extends ADORecordSet
+{
 
-  var $bind = false;
-  var $databaseType = "ads";
-  var $dataProvider = "ads";
-  var $useFetchArray;
-  var $_has_stupid_odbc_fetch_api_change = true;
+	var $bind = false;
+	var $databaseType = "ads";
+	var $dataProvider = "ads";
+	var $useFetchArray;
+	var $_has_stupid_odbc_fetch_api_change = true;
 
-  function __construct($id,$mode=false)
-  {
-    if ($mode === false) {
-      global $ADODB_FETCH_MODE;
-      $mode = $ADODB_FETCH_MODE;
-    }
-    $this->fetchMode = $mode;
+	function __construct($id, $mode = false)
+	{
+		if ($mode === false) {
+			global $ADODB_FETCH_MODE;
+			$mode = $ADODB_FETCH_MODE;
+		}
+		$this->fetchMode = $mode;
 
-    $this->_queryID = $id;
+		$this->_queryID = $id;
 
-    // the following is required for mysql odbc driver in 4.3.1 -- why?
-    $this->EOF = false;
-    $this->_currentRow = -1;
-    //parent::__construct($id);
-  }
-
-
-  // returns the field object
-  function &FetchField($fieldOffset = -1)
-  {
-
-    $off=$fieldOffset+1; // offsets begin at 1
-
-    $o= new ADOFieldObject();
-    $o->name = @ads_field_name($this->_queryID,$off);
-    $o->type = @ads_field_type($this->_queryID,$off);
-    $o->max_length = @ads_field_len($this->_queryID,$off);
-    if (ADODB_ASSOC_CASE == 0) $o->name = strtolower($o->name);
-    else if (ADODB_ASSOC_CASE == 1) $o->name = strtoupper($o->name);
-    return $o;
-  }
-
-  /* Use associative array to get fields array */
-  function Fields($colname)
-  {
-    if ($this->fetchMode & ADODB_FETCH_ASSOC) return $this->fields[$colname];
-    if (!$this->bind) {
-      $this->bind = array();
-      for ($i=0; $i < $this->_numOfFields; $i++) {
-        $o = $this->FetchField($i);
-        $this->bind[strtoupper($o->name)] = $i;
-      }
-    }
-
-     return $this->fields[$this->bind[strtoupper($colname)]];
-  }
+		// the following is required for mysql odbc driver in 4.3.1 -- why?
+		$this->EOF = false;
+		$this->_currentRow = -1;
+		//parent::__construct($id);
+	}
 
 
-  function _initrs()
-  {
-  global $ADODB_COUNTRECS;
-    $this->_numOfRows = ($ADODB_COUNTRECS) ? @ads_num_rows($this->_queryID) : -1;
-    $this->_numOfFields = @ads_num_fields($this->_queryID);
-    // some silly drivers such as db2 as/400 and intersystems cache return _numOfRows = 0
-    if ($this->_numOfRows == 0) $this->_numOfRows = -1;
-    //$this->useFetchArray = $this->connection->useFetchArray;
-  }
+	// returns the field object
+	function &FetchField($fieldOffset = -1)
+	{
 
-  function _seek($row)
-  {
-    return false;
-  }
+		$off = $fieldOffset + 1; // offsets begin at 1
 
-  // speed up SelectLimit() by switching to ADODB_FETCH_NUM as ADODB_FETCH_ASSOC is emulated
-  function &GetArrayLimit($nrows,$offset=-1)
-  {
-    if ($offset <= 0) {
-      $rs =& $this->GetArray($nrows);
-      return $rs;
-    }
-    $savem = $this->fetchMode;
-    $this->fetchMode = ADODB_FETCH_NUM;
-    $this->Move($offset);
-    $this->fetchMode = $savem;
+		$o = new ADOFieldObject();
+		$o->name = @ads_field_name($this->_queryID, $off);
+		$o->type = @ads_field_type($this->_queryID, $off);
+		$o->max_length = @ads_field_len($this->_queryID, $off);
+		if (ADODB_ASSOC_CASE == 0) {
+			$o->name = strtolower($o->name);
+		} else {
+			if (ADODB_ASSOC_CASE == 1) {
+				$o->name = strtoupper($o->name);
+			}
+		}
+		return $o;
+	}
 
-    if ($this->fetchMode & ADODB_FETCH_ASSOC) {
-      $this->fields =& $this->GetRowAssoc();
-    }
+	/* Use associative array to get fields array */
+	function Fields($colname)
+	{
+		if ($this->fetchMode & ADODB_FETCH_ASSOC) {
+			return $this->fields[$colname];
+		}
+		if (!$this->bind) {
+			$this->bind = array();
+			for ($i = 0; $i < $this->_numOfFields; $i++) {
+				$o = $this->FetchField($i);
+				$this->bind[strtoupper($o->name)] = $i;
+			}
+		}
 
-    $results = array();
-    $cnt = 0;
-    while (!$this->EOF && $nrows != $cnt) {
-      $results[$cnt++] = $this->fields;
-      $this->MoveNext();
-    }
-
-    return $results;
-  }
+		return $this->fields[$this->bind[strtoupper($colname)]];
+	}
 
 
-  function MoveNext()
-  {
-    if ($this->_numOfRows != 0 && !$this->EOF) {
-      $this->_currentRow++;
-      if( $this->_fetch() ) {
-          return true;
-      }
-    }
-    $this->fields = false;
-    $this->EOF = true;
-    return false;
-  }
+	function _initrs()
+	{
+		global $ADODB_COUNTRECS;
+		$this->_numOfRows = ($ADODB_COUNTRECS) ? @ads_num_rows($this->_queryID) : -1;
+		$this->_numOfFields = @ads_num_fields($this->_queryID);
+		// some silly drivers such as db2 as/400 and intersystems cache return _numOfRows = 0
+		if ($this->_numOfRows == 0) {
+			$this->_numOfRows = -1;
+		}
+		//$this->useFetchArray = $this->connection->useFetchArray;
+	}
 
-  function _fetch()
-  {
-    $this->fields = false;
-    if ($this->_has_stupid_odbc_fetch_api_change)
-      $rez = @ads_fetch_into($this->_queryID,$this->fields);
-    else {
-      $row = 0;
-      $rez = @ads_fetch_into($this->_queryID,$row,$this->fields);
-    }
-    if ($rez) {
-      if ($this->fetchMode & ADODB_FETCH_ASSOC) {
-        $this->fields =& $this->GetRowAssoc();
-      }
-      return true;
-    }
-    return false;
-  }
+	function _seek($row)
+	{
+		return false;
+	}
 
-  function _close()
-  {
-    return @ads_free_result($this->_queryID);
-  }
+	// speed up SelectLimit() by switching to ADODB_FETCH_NUM as ADODB_FETCH_ASSOC is emulated
+	function &GetArrayLimit($nrows, $offset = -1)
+	{
+		if ($offset <= 0) {
+			$rs =& $this->GetArray($nrows);
+			return $rs;
+		}
+		$savem = $this->fetchMode;
+		$this->fetchMode = ADODB_FETCH_NUM;
+		$this->Move($offset);
+		$this->fetchMode = $savem;
+
+		if ($this->fetchMode & ADODB_FETCH_ASSOC) {
+			$this->fields =& $this->GetRowAssoc();
+		}
+
+		$results = array();
+		$cnt = 0;
+		while (!$this->EOF && $nrows != $cnt) {
+			$results[$cnt++] = $this->fields;
+			$this->MoveNext();
+		}
+
+		return $results;
+	}
+
+
+	function MoveNext()
+	{
+		if ($this->_numOfRows != 0 && !$this->EOF) {
+			$this->_currentRow++;
+			if ($this->_fetch()) {
+				return true;
+			}
+		}
+		$this->fields = false;
+		$this->EOF = true;
+		return false;
+	}
+
+	function _fetch()
+	{
+		$this->fields = false;
+		if ($this->_has_stupid_odbc_fetch_api_change) {
+			$rez = @ads_fetch_into($this->_queryID, $this->fields);
+		} else {
+			$row = 0;
+			$rez = @ads_fetch_into($this->_queryID, $row, $this->fields);
+		}
+		if ($rez) {
+			if ($this->fetchMode & ADODB_FETCH_ASSOC) {
+				$this->fields =& $this->GetRowAssoc();
+			}
+			return true;
+		}
+		return false;
+	}
+
+	function _close()
+	{
+		return @ads_free_result($this->_queryID);
+	}
 
 }

--- a/drivers/adodb-firebird.inc.php
+++ b/drivers/adodb-firebird.inc.php
@@ -574,13 +574,8 @@ class ADODB_firebird extends ADOConnection {
 
 	function _BlobDecode( $blob )
 	{
-		if  (ADODB_PHPVER >= 0x5000) {
-			$blob_data = fbird_blob_info($this->_connectionID, $blob );
-			$blobid = fbird_blob_open($this->_connectionID, $blob );
-		} else {
-			$blob_data = fbird_blob_info( $blob );
-			$blobid = fbird_blob_open( $blob );
-		}
+		$blob_data = fbird_blob_info($this->_connectionID, $blob );
+		$blobid    = fbird_blob_open($this->_connectionID, $blob );
 
 		if( $blob_data[0] > $this->maxblobsize ) {
 			$realblob = fbird_blob_get($blobid, $this->maxblobsize);

--- a/drivers/adodb-firebird.inc.php
+++ b/drivers/adodb-firebird.inc.php
@@ -346,45 +346,26 @@ class ADODB_firebird extends ADOConnection {
 			$fn = 'fbird_execute';
 			$sql = $sql[1];
 			if (is_array($iarr)) {
-				if  (ADODB_PHPVER >= 0x4050) { // actually 4.0.4
-					if ( !isset($iarr[0]) ) $iarr[0] = ''; // PHP5 compat hack
-					$fnarr = array_merge( array($sql) , $iarr);
-					$ret = call_user_func_array($fn,$fnarr);
-				} else {
-					switch(sizeof($iarr)) {
-					case 1: $ret = $fn($sql,$iarr[0]); break;
-					case 2: $ret = $fn($sql,$iarr[0],$iarr[1]); break;
-					case 3: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2]); break;
-					case 4: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3]); break;
-					case 5: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4]); break;
-					case 6: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5]); break;
-					case 7: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5],$iarr[6]); break;
-					default: ADOConnection::outp( "Too many parameters to ibase query $sql");
-					case 8: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5],$iarr[6],$iarr[7]); break;
-					}
-				}
-			} else $ret = $fn($sql);
+				if ( !isset($iarr[0]) ) 
+					$iarr[0] = ''; // PHP5 compat hack
+				$fnarr = array_merge( array($sql) , $iarr);
+				$ret = call_user_func_array($fn,$fnarr);
+			}
+			else {
+				$ret = $fn($sql);
+			}
 		} else {
 			$fn = 'fbird_query';
-			if (is_array($iarr)) {
-				if (ADODB_PHPVER >= 0x4050) { // actually 4.0.4
-					if (sizeof($iarr) == 0) $iarr[0] = ''; // PHP5 compat hack
-					$fnarr = array_merge( array($conn,$sql) , $iarr);
-					$ret = call_user_func_array($fn,$fnarr);
-				} else {
-					switch(sizeof($iarr)) {
-					case 1: $ret = $fn($conn,$sql,$iarr[0]); break;
-					case 2: $ret = $fn($conn,$sql,$iarr[0],$iarr[1]); break;
-					case 3: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2]); break;
-					case 4: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3]); break;
-					case 5: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4]); break;
-					case 6: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5]); break;
-					case 7: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5],$iarr[6]); break;
-					default: ADOConnection::outp( "Too many parameters to ibase query $sql");
-					case 8: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5],$iarr[6],$iarr[7]); break;
-					}
-				}
-			} else $ret = $fn($conn,$sql);
+			if (is_array($iarr)) 
+			{
+				if (sizeof($iarr) == 0) 
+					$iarr[0] = ''; // PHP5 compat hack
+				$fnarr = array_merge( array($conn,$sql) , $iarr);
+				$ret = call_user_func_array($fn,$fnarr);
+			}
+			else {
+				$ret = $fn($conn, $sql);
+			}
 		}
 		if ($docommit && $ret === true) {
 			fbird_commit($this->_connectionID);

--- a/drivers/adodb-ibase.inc.php
+++ b/drivers/adodb-ibase.inc.php
@@ -581,14 +581,8 @@ class ADODB_ibase extends ADOConnection {
 
 	function _BlobDecode( $blob )
 	{
-		if  (ADODB_PHPVER >= 0x5000) {
-			$blob_data = ibase_blob_info($this->_connectionID, $blob );
-			$blobid = ibase_blob_open($this->_connectionID, $blob );
-		} else {
-
-			$blob_data = ibase_blob_info( $blob );
-			$blobid = ibase_blob_open( $blob );
-		}
+		$blob_data = ibase_blob_info($this->_connectionID, $blob );
+		$blobid    = ibase_blob_open($this->_connectionID, $blob );
 
 		if( $blob_data[0] > $this->maxblobsize ) {
 

--- a/drivers/adodb-ibase.inc.php
+++ b/drivers/adodb-ibase.inc.php
@@ -350,46 +350,26 @@ class ADODB_ibase extends ADOConnection {
 			$fn = 'ibase_execute';
 			$sql = $sql[1];
 			if (is_array($iarr)) {
-				if  (ADODB_PHPVER >= 0x4050) { // actually 4.0.4
-					if ( !isset($iarr[0]) ) $iarr[0] = ''; // PHP5 compat hack
-					$fnarr = array_merge( array($sql) , $iarr);
-					$ret = call_user_func_array($fn,$fnarr);
-				} else {
-					switch(sizeof($iarr)) {
-					case 1: $ret = $fn($sql,$iarr[0]); break;
-					case 2: $ret = $fn($sql,$iarr[0],$iarr[1]); break;
-					case 3: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2]); break;
-					case 4: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3]); break;
-					case 5: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4]); break;
-					case 6: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5]); break;
-					case 7: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5],$iarr[6]); break;
-					default: ADOConnection::outp( "Too many parameters to ibase query $sql");
-					case 8: $ret = $fn($sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5],$iarr[6],$iarr[7]); break;
-					}
-				}
-			} else $ret = $fn($sql);
+				if ( !isset($iarr[0]) ) 
+					$iarr[0] = ''; // PHP5 compat hack
+				$fnarr = array_merge( array($sql) , $iarr);
+				$ret = call_user_func_array($fn,$fnarr);
+			}
+			else {
+				$ret = $fn($sql);
+			}
 		} else {
 			$fn = 'ibase_query';
 
 			if (is_array($iarr)) {
-				if (ADODB_PHPVER >= 0x4050) { // actually 4.0.4
-					if (sizeof($iarr) == 0) $iarr[0] = ''; // PHP5 compat hack
-					$fnarr = array_merge( array($conn,$sql) , $iarr);
-					$ret = call_user_func_array($fn,$fnarr);
-				} else {
-					switch(sizeof($iarr)) {
-					case 1: $ret = $fn($conn,$sql,$iarr[0]); break;
-					case 2: $ret = $fn($conn,$sql,$iarr[0],$iarr[1]); break;
-					case 3: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2]); break;
-					case 4: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3]); break;
-					case 5: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4]); break;
-					case 6: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5]); break;
-					case 7: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5],$iarr[6]); break;
-					default: ADOConnection::outp( "Too many parameters to ibase query $sql");
-					case 8: $ret = $fn($conn,$sql,$iarr[0],$iarr[1],$iarr[2],$iarr[3],$iarr[4],$iarr[5],$iarr[6],$iarr[7]); break;
-					}
-				}
-			} else $ret = $fn($conn,$sql);
+				if (sizeof($iarr) == 0) 
+					$iarr[0] = ''; // PHP5 compat hack
+				$fnarr = array_merge( array($conn,$sql) , $iarr);
+				$ret = call_user_func_array($fn,$fnarr);
+			}
+			else {
+				$ret = $fn($conn, $sql);
+			}
 		}
 		if ($docommit && $ret === true) {
 			ibase_commit($this->_connectionID);

--- a/drivers/adodb-mssql.inc.php
+++ b/drivers/adodb-mssql.inc.php
@@ -62,7 +62,6 @@ class ADODB_mssql extends ADOConnection {
 	var $hasGenID = true;
 	var $sysDate = 'convert(datetime,convert(char,GetDate(),102),102)';
 	var $sysTimeStamp = 'GetDate()';
-	var $_has_mssql_init;
 	var $maxParameterLen = 4000;
 	var $arrayClass = 'ADORecordSet_array_mssql';
 	var $uniqueSort = true;
@@ -74,11 +73,6 @@ class ADODB_mssql extends ADOConnection {
 	var $uniqueOrderBy = true;
 	var $_bindInputArray = true;
 	var $forceNewConnect = false;
-
-	function __construct()
-	{
-		$this->_has_mssql_init = (strnatcmp(PHP_VERSION,'4.1.0')>=0);
-	}
 
 	function ServerInfo()
 	{
@@ -637,10 +631,6 @@ order by constraint_name, referenced_table_name, keyno";
 
 	function PrepareSP($sql,$param=true)
 	{
-		if (!$this->_has_mssql_init) {
-			ADOConnection::outp( "PrepareSP: mssql_init only available since PHP 4.1.0");
-			return $sql;
-		}
 		$stmt = mssql_init($sql,$this->_connectionID);
 		if (!$stmt)  return $sql;
 		return array($sql,$stmt);
@@ -695,11 +685,6 @@ order by constraint_name, referenced_table_name, keyno";
 	*/
 	function Parameter(&$stmt, &$var, $name, $isOutput=false, $maxLen=4000, $type=false)
 	{
-		if (!$this->_has_mssql_init) {
-			ADOConnection::outp( "Parameter: mssql_bind only available since PHP 4.1.0");
-			return false;
-		}
-
 		$isNull = is_null($var); // php 4.0.4 and above...
 
 		if ($type === false)
@@ -709,7 +694,7 @@ order by constraint_name, referenced_table_name, keyno";
 			case 'double': $type = SQLFLT8; break;
 			case 'integer': $type = SQLINT4; break;
 			case 'boolean': $type = SQLINT1; break; # SQLBIT not supported in 4.1.0
-			}
+		}
 
 		if  ($this->debug) {
 			$prefix = ($isOutput) ? 'Out' : 'In';

--- a/drivers/adodb-mssql.inc.php
+++ b/drivers/adodb-mssql.inc.php
@@ -1161,10 +1161,11 @@ class ADORecordSet_array_mssql extends ADORecordSet_array {
 	// mssql uses a default date like Dec 30 2000 12:00AM
 	static function UnixDate($v)
 	{
+		if (is_numeric(substr($v,0,1))) {
+			return parent::UnixDate($v);
+		}
 
-		if (is_numeric(substr($v,0,1)) && ADODB_PHPVER >= 0x4200) return parent::UnixDate($v);
-
-	global $ADODB_mssql_mths,$ADODB_mssql_date_order;
+		global $ADODB_mssql_mths,$ADODB_mssql_date_order;
 
 		//Dec 30 2000 12:00AM
 		if ($ADODB_mssql_date_order == 'dmy') {
@@ -1192,10 +1193,11 @@ class ADORecordSet_array_mssql extends ADORecordSet_array {
 
 	static function UnixTimeStamp($v)
 	{
+		if (is_numeric(substr($v,0,1))) {
+			return parent::UnixTimeStamp($v);
+		}
 
-		if (is_numeric(substr($v,0,1)) && ADODB_PHPVER >= 0x4200) return parent::UnixTimeStamp($v);
-
-	global $ADODB_mssql_mths,$ADODB_mssql_date_order;
+		global $ADODB_mssql_mths,$ADODB_mssql_date_order;
 
 		//Dec 30 2000 12:00AM
 		if ($ADODB_mssql_date_order == 'dmy') {

--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -1287,8 +1287,9 @@ class ADORecordSet_array_mssqlnative extends ADORecordSet_array {
 	// mssql uses a default date like Dec 30 2000 12:00AM
 	static function UnixDate($v)
 	{
-
-		if (is_numeric(substr($v,0,1)) && ADODB_PHPVER >= 0x4200) return parent::UnixDate($v);
+		if (is_numeric(substr($v,0,1))) {
+			return parent::UnixDate($v);
+		}
 
 		global $ADODB_mssql_mths,$ADODB_mssql_date_order;
 
@@ -1318,8 +1319,9 @@ class ADORecordSet_array_mssqlnative extends ADORecordSet_array {
 
 	static function UnixTimeStamp($v)
 	{
-
-		if (is_numeric(substr($v,0,1)) && ADODB_PHPVER >= 0x4200) return parent::UnixTimeStamp($v);
+		if (is_numeric(substr($v,0,1))) {
+			return parent::UnixTimeStamp($v);
+		}
 
 		global $ADODB_mssql_mths,$ADODB_mssql_date_order;
 

--- a/drivers/adodb-mssqlpo.inc.php
+++ b/drivers/adodb-mssqlpo.inc.php
@@ -32,10 +32,6 @@ class ADODB_mssqlpo extends ADODB_mssql {
 
 	function PrepareSP($sql, $param = true)
 	{
-		if (!$this->_has_mssql_init) {
-			ADOConnection::outp( "PrepareSP: mssql_init only available since PHP 4.1.0");
-			return $sql;
-		}
 		if (is_string($sql)) $sql = str_replace('||','+',$sql);
 		$stmt = mssql_init($sql,$this->_connectionID);
 		if (!$stmt)  return $sql;

--- a/drivers/adodb-mysql.inc.php
+++ b/drivers/adodb-mysql.inc.php
@@ -251,10 +251,10 @@ class ADODB_mysql extends ADOConnection {
 		if (is_null($s)) return 'NULL';
 		if (!$magic_quotes) {
 
-			if (ADODB_PHPVER >= 0x4300) {
-				if (is_resource($this->_connectionID))
-					return "'".mysql_real_escape_string($s,$this->_connectionID)."'";
+			if (is_resource($this->_connectionID)) {
+				return "'" . mysql_real_escape_string($s, $this->_connectionID) . "'";
 			}
+
 			if ($this->replaceQuote[0] == '\\'){
 				$s = adodb_str_replace(array('\\',"\0"),array('\\\\',"\\\0"),$s);
 			}
@@ -474,19 +474,23 @@ class ADODB_mysql extends ADOConnection {
 	// returns true or false
 	function _connect($argHostname, $argUsername, $argPassword, $argDatabasename)
 	{
-		if (!empty($this->port)) $argHostname .= ":".$this->port;
+		if (!empty($this->port)) 
+			$argHostname .= ":".$this->port;
 
-		if (ADODB_PHPVER >= 0x4300)
-			$this->_connectionID = mysql_connect($argHostname,$argUsername,$argPassword,
-												$this->forceNewConnect,$this->clientFlags);
-		else if (ADODB_PHPVER >= 0x4200)
-			$this->_connectionID = mysql_connect($argHostname,$argUsername,$argPassword,
-												$this->forceNewConnect);
-		else
-			$this->_connectionID = mysql_connect($argHostname,$argUsername,$argPassword);
+		$this->_connectionID = 
+			mysql_connect($argHostname,
+						  $argUsername,
+						  $argPassword,
+						  $this->forceNewConnect,
+						  $this->clientFlags
+						  );
+		
 
-		if ($this->_connectionID === false) return false;
-		if ($argDatabasename) return $this->SelectDB($argDatabasename);
+		if ($this->_connectionID === false) 
+			return false;
+		if ($argDatabasename) 
+			return $this->SelectDB($argDatabasename);
+		
 		return true;
 	}
 
@@ -495,13 +499,18 @@ class ADODB_mysql extends ADOConnection {
 	{
 		if (!empty($this->port)) $argHostname .= ":".$this->port;
 
-		if (ADODB_PHPVER >= 0x4300)
-			$this->_connectionID = mysql_pconnect($argHostname,$argUsername,$argPassword,$this->clientFlags);
-		else
-			$this->_connectionID = mysql_pconnect($argHostname,$argUsername,$argPassword);
-		if ($this->_connectionID === false) return false;
-		if ($this->autoRollback) $this->RollbackTrans();
-		if ($argDatabasename) return $this->SelectDB($argDatabasename);
+		$this->_connectionID = 
+			mysql_pconnect($argHostname,
+						   $argUsername,
+						   $argPassword,
+						   $this->clientFlags);
+		
+		if ($this->_connectionID === false) 
+			return false;
+		if ($this->autoRollback) 
+			$this->RollbackTrans();
+		if ($argDatabasename) 
+			return $this->SelectDB($argDatabasename);
 		return true;
 	}
 

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -149,7 +149,9 @@ class ADODB_mysqli extends ADOConnection {
 		}
 
 		//https://php.net/manual/en/mysqli.persistconns.php
-		if ($persist && PHP_VERSION > 5.2 && strncmp($argHostname,'p:',2) != 0) $argHostname = 'p:'.$argHostname;
+		if ($persist && strncmp($argHostname,'p:',2) != 0) {
+			$argHostname = 'p:' . $argHostname;
+		}
 
 		// SSL Connections for MySQLI
 		if ($this->ssl_key || $this->ssl_cert || $this->ssl_ca || $this->ssl_capath || $this->ssl_cipher) {

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -365,7 +365,7 @@ class ADODB_mysqli extends ADOConnection {
 		if (!$magic_quotes) {
 			// mysqli_real_escape_string() throws a warning when the given
 			// connection is invalid
-			if (PHP_VERSION >= 5 && $this->_connectionID) {
+			if ($this->_connectionID) {
 				return "'" . mysqli_real_escape_string($this->_connectionID, $s) . "'";
 			}
 

--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -118,13 +118,6 @@ END;
 	 */
 	public $seqPrefix = 'SEQ_';
 
-
-	
-	function __construct()
-	{
-		$this->_hasOciFetchStatement = ADODB_PHPVER >= 0x4200;
-	}
-
 	/*  function MetaColumns($table, $normalize=true) added by smondino@users.sourceforge.net*/
 	function MetaColumns($table, $normalize=true)
 	{

--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -89,7 +89,7 @@ END;
 	var $connectSID = false;
 	var $_bind = false;
 	var $_nestedSQL = true;
-	var $_hasOciFetchStatement = false;
+	var $_hasOciFetchStatement = true;
 	var $_getarray = false; // currently not working
 	var $leftOuter = '';  // oracle wierdness, $col = $value (+) for LEFT OUTER, $col (+)= $value for RIGHT OUTER
 	var $session_sharing_force_blob = false; // alter session on updateblob if set to true
@@ -104,18 +104,18 @@ END;
 	// var $ansiOuter = true; // if oracle9
 
 	/*
-	* Legacy compatibility for sequence names for emulated auto-increments
-	*/
+	 * Legacy compatibility for sequence names for emulated auto-increments
+	 */
 	public $useCompactAutoIncrements = false;
 	
 	/*
-	* Defines the schema name for emulated auto-increment columns
-	*/
+	 * Defines the schema name for emulated auto-increment columns
+	 */
 	public $schema = false;
 	
 	/*
-	* Defines the prefix for emulated auto-increment columns
-	*/
+	 * Defines the prefix for emulated auto-increment columns
+	 */
 	public $seqPrefix = 'SEQ_';
 
 

--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -89,7 +89,6 @@ END;
 	var $connectSID = false;
 	var $_bind = false;
 	var $_nestedSQL = true;
-	var $_hasOciFetchStatement = true;
 	var $_getarray = false; // currently not working
 	var $leftOuter = '';  // oracle wierdness, $col = $value (+) for LEFT OUTER, $col (+)= $value for RIGHT OUTER
 	var $session_sharing_force_blob = false; // alter session on updateblob if set to true

--- a/drivers/adodb-oci8po.inc.php
+++ b/drivers/adodb-oci8po.inc.php
@@ -30,11 +30,6 @@ class ADODB_oci8po extends ADODB_oci8 {
 	var $metaColumnsSQL = "select lower(cname),coltype,width, SCALE, PRECISION, NULLS, DEFAULTVAL from col where tname='%s' order by colno"; //changed by smondino@users.sourceforge. net
 	var $metaTablesSQL = "select lower(table_name),table_type from cat where table_type in ('TABLE','VIEW')";
 
-	function __construct()
-	{
-		$this->_hasOCIFetchStatement = ADODB_PHPVER >= 0x4200;
-	}
-
 	function Param($name,$type='C')
 	{
 		return '?';

--- a/drivers/adodb-odbc.inc.php
+++ b/drivers/adodb-odbc.inc.php
@@ -48,7 +48,6 @@ class ADODB_odbc extends ADOConnection {
 	var $curmode = SQL_CUR_USE_DRIVER; // See sqlext.h, SQL_CUR_DEFAULT == SQL_CUR_USE_DRIVER == 2L
 	var $_genSeqSQL = "create table %s (id integer)";
 	var $_autocommit = true;
-	var $_has_stupid_odbc_fetch_api_change = true;
 	var $_lastAffectedRows = 0;
 	var $uCaseTables = true; // for meta* functions, uppercase table names
 	
@@ -265,7 +264,6 @@ class ADODB_odbc extends ADOConnection {
 		$ADODB_FETCH_MODE = $savem;
 
 		if (!$rs) return false;
-		$rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
 
 		$arr = $rs->GetArray();
 		$rs->Close();
@@ -294,7 +292,6 @@ class ADODB_odbc extends ADOConnection {
 			$false = false;
 			return $false;
 		}
-		$rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
 
 		$arr = $rs->GetArray();
 		//print_r($arr);
@@ -402,7 +399,6 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
 			$rs = new ADORecordSet_odbc($qid2);
 			$ADODB_FETCH_MODE = $savem;
 			if (!$rs) return false;
-			$rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
 			$rs->_fetch();
 
 			while (!$rs->EOF) {
@@ -441,7 +437,6 @@ See http://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbc/htm/od
 		$ADODB_FETCH_MODE = $savem;
 
 		if (!$rs) return $false;
-		$rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
 		$rs->_fetch();
 
 		$retarr = array();
@@ -607,7 +602,6 @@ class ADORecordSet_odbc extends ADORecordSet {
 	var $databaseType = "odbc";
 	var $dataProvider = "odbc";
 	var $useFetchArray;
-	var $_has_stupid_odbc_fetch_api_change = true;
 
 	function __construct($id,$mode=false)
 	{
@@ -715,12 +709,7 @@ class ADORecordSet_odbc extends ADORecordSet {
 	function _fetch()
 	{
 		$this->fields = false;
-		if ($this->_has_stupid_odbc_fetch_api_change)
-			$rez = @odbc_fetch_into($this->_queryID,$this->fields);
-		else {
-			$row = 0;
-			$rez = @odbc_fetch_into($this->_queryID,$row,$this->fields);
-		}
+		$rez = @odbc_fetch_into($this->_queryID,$this->fields);
 		if ($rez) {
 			if ($this->fetchMode & ADODB_FETCH_ASSOC) {
 				$this->fields = $this->GetRowAssoc();

--- a/drivers/adodb-odbc.inc.php
+++ b/drivers/adodb-odbc.inc.php
@@ -58,11 +58,7 @@ class ADODB_odbc extends ADOConnection {
 	 */
 	public $metaColumnsReturnType = METACOLUMNS_RETURNS_ACTUAL;
 
-	function __construct()
-	{
-		$this->_haserrorfunctions = ADODB_PHPVER >= 0x4050;
-		$this->_has_stupid_odbc_fetch_api_change = ADODB_PHPVER >= 0x4200;
-	}
+	function __construct() {}
 
 		// returns true or false
 	function _connect($argDSN, $argUsername, $argPassword, $argDatabasename)
@@ -110,7 +106,7 @@ class ADODB_odbc extends ADOConnection {
 	function ServerInfo()
 	{
 
-		if (!empty($this->host) && ADODB_PHPVER >= 0x4300) {
+		if (!empty($this->host)) {
 			$dsn = strtoupper($this->host);
 			$first = true;
 			$found = false;
@@ -629,7 +625,7 @@ class ADORecordSet_odbc extends ADORecordSet {
 	var $databaseType = "odbc";
 	var $dataProvider = "odbc";
 	var $useFetchArray;
-	var $_has_stupid_odbc_fetch_api_change;
+	var $_has_stupid_odbc_fetch_api_change = true;
 
 	function __construct($id,$mode=false)
 	{
@@ -687,7 +683,6 @@ class ADORecordSet_odbc extends ADORecordSet {
 		// some silly drivers such as db2 as/400 and intersystems cache return _numOfRows = 0
 		if ($this->_numOfRows == 0) $this->_numOfRows = -1;
 		//$this->useFetchArray = $this->connection->useFetchArray;
-		$this->_has_stupid_odbc_fetch_api_change = ADODB_PHPVER >= 0x4200;
 	}
 
 	function _seek($row)

--- a/drivers/adodb-odbc_db2.inc.php
+++ b/drivers/adodb-odbc_db2.inc.php
@@ -157,7 +157,6 @@ class ADODB_ODBC_DB2 extends ADODB_odbc {
 			$false = false;
 			return $false;
 		}
-		$rs->_has_stupid_odbc_fetch_api_change = $this->_has_stupid_odbc_fetch_api_change;
 
 		$arr = $rs->GetArray();
 		//print_r($arr);

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -220,10 +220,7 @@ class ADODB_pdo extends ADOConnection {
 			return call_user_func_array(array($this->_driver, 'Concat'), $args);
 		}
 
-		if (PHP_VERSION >= 5.3) {
-			return call_user_func_array('parent::Concat', $args);
-		}
-		return call_user_func_array(array($this,'parent::Concat'), $args);
+		return call_user_func_array('parent::Concat', $args);
 	}
 
 	// returns true or false

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -77,7 +77,6 @@ class ADODB_pdo extends ADOConnection {
 	var $_genSeqSQL = "create table %s (id integer)";
 	var $_dropSeqSQL;
 	var $_autocommit = true;
-	var $_haserrorfunctions = true;
 	var $_lastAffectedRows = 0;
 
 	var $_errormsg = false;

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -460,15 +460,7 @@ class ADODB_postgres64 extends ADOConnection{
 	 */
 	function BlobEncode($blob)
 	{
-		if (ADODB_PHPVER >= 0x5200) return pg_escape_bytea($this->_connectionID, $blob);
-		if (ADODB_PHPVER >= 0x4200) return pg_escape_bytea($blob);
-
-		/*92=backslash, 0=null, 39=single-quote*/
-		$badch = array(chr(92),chr(0),chr(39)); # \  null  '
-		$fixch = array('\\\\134','\\\\000','\\\\047');
-		return adodb_str_replace($badch,$fixch,$blob);
-
-		// note that there is a pg_escape_bytea function only for php 4.2.0 or later
+		return pg_escape_bytea($this->_connectionID, $blob);
 	}
 
 	// assumes bytea for blob, and varchar for clob
@@ -872,20 +864,23 @@ class ADODB_postgres64 extends ADOConnection{
 	/*	Returns: the last error message from previous database operation	*/
 	function ErrorMsg()
 	{
-		if ($this->_errorMsg !== false) return $this->_errorMsg;
-		if (ADODB_PHPVER >= 0x4300) {
-			if (!empty($this->_resultid)) {
-				$this->_errorMsg = @pg_result_error($this->_resultid);
-				if ($this->_errorMsg) return $this->_errorMsg;
-			}
-
-			if (!empty($this->_connectionID)) {
-				$this->_errorMsg = @pg_last_error($this->_connectionID);
-			} else $this->_errorMsg = $this->_errconnect();
-		} else {
-			if (empty($this->_connectionID)) $this->_errconnect();
-			else $this->_errorMsg = @pg_errormessage($this->_connectionID);
+		if ($this->_errorMsg !== false) {
+			return $this->_errorMsg;
 		}
+		
+		if (!empty($this->_resultid)) {
+			$this->_errorMsg = @pg_result_error($this->_resultid);
+			if ($this->_errorMsg) {
+				return $this->_errorMsg;
+			}
+		}
+
+		if (!empty($this->_connectionID)) {
+			$this->_errorMsg = @pg_last_error($this->_connectionID);
+		} else {
+			$this->_errorMsg = $this->_errconnect();
+		}
+
 		return $this->_errorMsg;
 	}
 

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -270,16 +270,12 @@ class ADODB_postgres64 extends ADOConnection{
 		if (is_bool($s)) return $s ? 'true' : 'false';
 
 		if (!$magic_quotes) {
-			if (ADODB_PHPVER >= 0x5200 && $this->_connectionID) {
-				return  "'".pg_escape_string($this->_connectionID,$s)."'";
+			if ($this->_connectionID) {
+				return "'" . pg_escape_string($this->_connectionID, $s) . "'";
 			}
-			if (ADODB_PHPVER >= 0x4200) {
-				return  "'".pg_escape_string($s)."'";
+			else {
+				return "'" . pg_escape_string($s) . "'";
 			}
-			if ($this->replaceQuote[0] == '\\'){
-				$s = adodb_str_replace(array('\\',"\0"),array('\\\\',"\\\\000"),$s);
-			}
-			return  "'".str_replace("'",$this->replaceQuote,$s)."'";
 		}
 
 		// undo magic quotes for "

--- a/drivers/adodb-postgres7.inc.php
+++ b/drivers/adodb-postgres7.inc.php
@@ -101,7 +101,7 @@ class ADODB_postgres7 extends ADODB_postgres64 {
 		if (ADODB_ASSOC_CASE !== ADODB_ASSOC_CASE_NATIVE) {
 			$this->rsPrefix .= 'assoc_';
 		}
-		$this->_bindInputArray = PHP_VERSION >= 5.1;
+		$this->_bindInputArray = true;
 	}
 
 

--- a/drivers/adodb-sybase.inc.php
+++ b/drivers/adodb-sybase.inc.php
@@ -167,7 +167,7 @@ class ADODB_sybase extends ADOConnection {
 	{
 	global $ADODB_COUNTRECS;
 
-		if ($ADODB_COUNTRECS == false && ADODB_PHPVER >= 0x4300)
+		if ($ADODB_COUNTRECS == false)
 			return sybase_unbuffered_query($sql,$this->_connectionID);
 		else
 			return sybase_query($sql,$this->_connectionID);

--- a/tests/test-active-record.php
+++ b/tests/test-active-record.php
@@ -5,10 +5,7 @@
 
 	// uncomment the following if you want to test exceptions
 	if (@$_GET['except']) {
-		if (PHP_VERSION >= 5) {
-			include('../adodb-exceptions.inc.php');
-			echo "<h3>Exceptions included</h3>";
-		}
+		include('../adodb-exceptions.inc.php');
 	}
 
 	$db = NewADOConnection('mysql://root@localhost/northwind?persist');

--- a/tests/test.php
+++ b/tests/test.php
@@ -28,7 +28,6 @@ function getmicrotime()
 }
 
 
-if (PHP_VERSION < 5) include_once('../adodb-pear.inc.php');
 //--------------------------------------------------------------------------------------
 //define('ADODB_ASSOC_CASE',1);
 //
@@ -1346,11 +1345,6 @@ END Adodb;
 
 	$rs = $db->SelectLimit('select id,firstname,lastname,created,\'The	"young man", he said\' from ADOXYZ',10);
 
-	if (PHP_VERSION < 5) {
-		print "<pre>";
-		rs2tabout($rs);
-		print "</pre>";
-	}
 	#print " CacheFlush ";
 	#$db->CacheFlush();
 
@@ -1645,16 +1639,21 @@ END Adodb;
 	print "<p>Testing Bad Connection</p>";
 	flush();
 
-	if (true || PHP_VERSION < 5)  {
-		if ($db->dataProvider == 'odbtp') $db->databaseType = 'odbtp';
-		$conn = NewADOConnection($db->databaseType);
-		$conn->raiseErrorFn = 'adodb_test_err';
-		if (1) $conn->PConnect('abc','baduser','badpassword');
-		if ($TESTERRS == 2) print "raiseErrorFn tests passed<br>";
-		else print "<b>raiseErrorFn tests failed ($TESTERRS)</b><br>";
-
-		flush();
+	if ($db->dataProvider == 'odbtp') {
+		$db->databaseType = 'odbtp';
 	}
+	$conn = NewADOConnection($db->databaseType);
+	$conn->raiseErrorFn = 'adodb_test_err';
+	$conn->PConnect('abc','baduser','badpassword');
+	if ($TESTERRS == 2) {
+		print "raiseErrorFn tests passed<br>";
+	}
+	else {
+		print "<b>raiseErrorFn tests failed ($TESTERRS)</b><br>";
+	}
+
+	flush();
+
 	////////////////////////////////////////////////////////////////////
 
 	global $nocountrecs;

--- a/tests/test4.php
+++ b/tests/test4.php
@@ -45,12 +45,11 @@ $conn->PConnect("localhost", "root", "", "test"); // connect to MySQL, testdb
 #$conn = ADONewConnection('oci8po');
 #$conn->Connect('','scott','natsoft');
 
-if (PHP_VERSION  >= 5) {
-	$connstr = "mysql:dbname=northwind";
-	$u = 'root';$p='';
-	$conn = ADONewConnection('pdo');
-	$conn->Connect($connstr, $u, $p);
-}
+$connstr = "mysql:dbname=northwind";
+$u = 'root';$p='';
+$conn = ADONewConnection('pdo');
+$conn->Connect($connstr, $u, $p);
+
 //$ADODB_FETCH_MODE = ADODB_FETCH_ASSOC;
 
 

--- a/tests/testdatabases.inc.php
+++ b/tests/testdatabases.inc.php
@@ -275,8 +275,7 @@ if (!empty($testvfp)) { // ODBC
 if (!empty($testmysql)) { // MYSQL
 
 
-	if (PHP_VERSION >= 5 || $_SERVER['HTTP_HOST'] == 'localhost') $server = 'localhost';
-	else $server = "mangrove";
+	$server = 'localhost';
 	$user = 'root'; $password = ''; $database = 'northwind';
 	$db = ADONewConnection("mysqlt://$user:$password@$server/$database?persist");
 	print "<h1>Connecting $db->databaseType...</h1>";
@@ -294,8 +293,7 @@ if (!empty($testmysqli)) { // MYSQL
 
 	$db = ADONewConnection('mysqli');
 	print "<h1>Connecting $db->databaseType...</h1>";
-	if (PHP_VERSION >= 5 || $_SERVER['HTTP_HOST'] == 'localhost') $server = 'localhost';
-	else $server = "mangrove";
+	$server = 'localhost';
 	if ($db->PConnect($server, "root", "", "northwind")) {
 		//$db->debug=1;$db->Execute('drop table ADOXYZ');
 		testdb($db,
@@ -310,8 +308,7 @@ if (!empty($testmysqlodbc)) { // MYSQL
 	$db = ADONewConnection('odbc');
 	$db->hasTransactions = false;
 	print "<h1>Connecting $db->databaseType...</h1>";
-	if ($_SERVER['HTTP_HOST'] == 'localhost') $server = 'localhost';
-	else $server = "mangrove";
+	$server = 'localhost';
 	if ($db->PConnect('mysql', "root", ""))
 		testdb($db,
 		"create table ADOXYZ (id int, firstname char(24), lastname char(24), created date) type=innodb");
@@ -321,7 +318,7 @@ if (!empty($testmysqlodbc)) { // MYSQL
 if (!empty($testproxy)){
 	$db = ADONewConnection('proxy');
 	print "<h1>Connecting $db->databaseType...</h1>";
-	if ($_SERVER['HTTP_HOST'] == 'localhost') $server = 'localhost';
+	$server = 'localhost';
 
 	if ($db->PConnect('http://localhost/php/phplens/adodb/server.php'))
 		testdb($db,
@@ -358,25 +355,15 @@ if (false && !empty($testoracle)) {
 
 ADOLoadCode("odbc_db2"); // no longer supported
 if (!empty($testdb2)) {
-	if (PHP_VERSION>=5.1) {
-		$db = ADONewConnection("db2");
-		print "<h1>Connecting $db->databaseType...</h1>";
+	$db = ADONewConnection("db2");
+	print "<h1>Connecting $db->databaseType...</h1>";
 
-		#$db->curMode = SQL_CUR_USE_ODBC;
-		#$dsn = "driver={IBM db2 odbc DRIVER};Database=test;hostname=localhost;port=50000;protocol=TCPIP; uid=natsoft; pwd=guest";
-		if ($db->Connect('localhost','natsoft','guest','test')) {
-			testdb($db,"create table ADOXYZ (id int, firstname varchar(24), lastname varchar(24),created date)");
-		} else print "ERROR: DB2 test requires an server setup with odbc data source db2_sample".'<BR>'.$db->ErrorMsg();
+	#$db->curMode = SQL_CUR_USE_ODBC;
+	#$dsn = "driver={IBM db2 odbc DRIVER};Database=test;hostname=localhost;port=50000;protocol=TCPIP; uid=natsoft; pwd=guest";
+	if ($db->Connect('localhost','natsoft','guest','test')) {
+		testdb($db,"create table ADOXYZ (id int, firstname varchar(24), lastname varchar(24),created date)");
 	} else {
-		$db = ADONewConnection("odbc_db2");
-		print "<h1>Connecting $db->databaseType...</h1>";
-
-		$dsn = "db2test";
-		#$db->curMode = SQL_CUR_USE_ODBC;
-		#$dsn = "driver={IBM db2 odbc DRIVER};Database=test;hostname=localhost;port=50000;protocol=TCPIP; uid=natsoft; pwd=guest";
-		if ($db->Connect($dsn)) {
-			testdb($db,"create table ADOXYZ (id int, firstname varchar(24), lastname varchar(24),created date)");
-		} else print "ERROR: DB2 test requires an server setup with odbc data source db2_sample".'<BR>'.$db->ErrorMsg();
+		print "ERROR: DB2 test requires an server setup with odbc data source db2_sample".'<BR>'.$db->ErrorMsg();
 	}
 echo "<hr />";
 flush();


### PR DESCRIPTION
The product contains numerous tests for PHP 4 and 5 that create unneeded code branches and links to obsolete functions.

Included in this cleanup is the removal of the ADODB_PHPVER constant and global

Not included are some tests in drivers scheduled for removal in the next release

Fixes #584 