### PR TITLE
Retrieve SQL Server Affected Rows early before connection closes

### DIFF
--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -431,7 +431,6 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
 		// also see http://phplens.com/lens/lensforum/msgs.php?id=12752
 		$rewritesql = adodb_strip_order_by($rewritesql);
 	}
-
 	if (isset($rewritesql) && $rewritesql != $sql) {
 		if (preg_match('/\sLIMIT\s+[0-9]+/i',$sql,$limitarr)) $rewritesql .= $limitarr[0];
 
@@ -441,6 +440,7 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
 			$qryRecs = $zthis->CacheGetOne($secs2cache/2,$rewritesql,$inputarr);
 
 		} else {
+			//print $rewritesql; exit;
 			$qryRecs = $zthis->GetOne($rewritesql,$inputarr);
 	  	}
 		if ($qryRecs !== false) return $qryRecs;

--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -93,6 +93,11 @@ class ADODB_mssqlnative extends ADOConnection {
 
 	var $sequences = false;
 	var $mssql_version = '';
+	
+	/*
+	* Stores the affected rows after a query
+	*/
+	private $sqlServerAffectedRows = -1;
 
 	function __construct()
 	{
@@ -162,8 +167,13 @@ class ADODB_mssqlnative extends ADOConnection {
 
 	function _affectedrows()
 	{
-		if ($this->_queryID)
-		return sqlsrv_rows_affected($this->_queryID);
+		/*
+		* If a non-update statement, sql server returns
+		* -1, ADODb needs false
+		*/
+		if ($this->sqlServerAffectedRows == -1)
+			return false;
+		return $this->sqlServerAffectedRows;
 	}
 
 	function GenID($seq='adodbseq',$start=1) {
@@ -595,6 +605,12 @@ class ADODB_mssqlnative extends ADOConnection {
 
 		if ($this->debug) ADOConnection::outp("<hr>running query: ".var_export($sql,true)."<hr>input array: ".var_export($inputarr,true)."<hr>result: ".var_export($rez,true));
 
+		/*
+		* Store off the affected rows for retrieval later
+		*/
+		$this->sqlServerAffectedRows = sqlsrv_rows_affected($rez);
+		
+		
 		if(!$rez)
 			$rez = false;
 

--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -608,7 +608,8 @@ class ADODB_mssqlnative extends ADOConnection {
 		/*
 		* Store off the affected rows for retrieval later
 		*/
-		$this->sqlServerAffectedRows = sqlsrv_rows_affected($rez);
+		if (is_resource($rez))
+			$this->sqlServerAffectedRows = sqlsrv_rows_affected($rez);
 		
 		
 		if(!$rez)


### PR DESCRIPTION
Patch for #590 closes the connection early, making affected_rows() fail. In addition, the value returned for an invalid query (-1) does not conform to the ADOdb standard (false). Affected Rows is now retrieved immediately after query execution and stored for later use.

Fixes #606 

@dregad This needs to go into the new release, if you've already built it, I'm afraid we need to create a hotfix 