### PR TITLE
remove magic_quotes stuff from adodb-xmlschema03.inc.php

### DIFF
--- a/adodb-xmlschema03.inc.php
+++ b/adodb-xmlschema03.inc.php
@@ -1366,12 +1366,6 @@ class adoSchema {
 	var $objectPrefix = '';
 
 	/**
-	* @var long	Original Magic Quotes Runtime value
-	* @access private
-	*/
-	var $mgq;
-
-	/**
 	* @var long	System debug
 	* @access private
 	*/
@@ -1419,12 +1413,6 @@ class adoSchema {
 	* @param object $db ADOdb database connection object.
 	*/
 	function __construct( $db ) {
-		// Initialize the environment
-		$this->mgq = get_magic_quotes_runtime();
-		if ($this->mgq !== false) {
-			ini_set('magic_quotes_runtime', 0 );
-		}
-
 		$this->db = $db;
 		$this->debug = $this->db->debug;
 		$this->dict = NewDataDictionary( $this->db );
@@ -2390,9 +2378,6 @@ class adoSchema {
 	* @deprecated adoSchema now cleans up automatically.
 	*/
 	function destroy() {
-		if ($this->mgq !== false) {
-			ini_set('magic_quotes_runtime', $this->mgq );
-		}
 	}
 }
 


### PR DESCRIPTION
always false since PHP 5.4 and finally removed by PHP 8.0