### PR TITLE
pgsql: Fix param(0) returning invalid $0 placeholder

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1004,15 +1004,19 @@ if (!defined('_ADODB_LAYER')) {
 	}
 
 	/**
-	 * Returns a placeholder for query parameters
+	 * Returns a placeholder for query parameters.
+	 *
 	 * e.g. $DB->Param('a') will return
 	 * - '?' for most databases
 	 * - ':a' for Oracle
 	 * - '$1', '$2', etc. for PostgreSQL
-	 * @param string $name parameter's name, false to force a reset of the
-	 *                     number to 1 (for databases that require positioned
-	 *                     params such as PostgreSQL; note that ADOdb will
-	 *                     automatically reset this when executing a query )
+	 *
+	 * @param mixed $name parameter's name.
+	 *                    For databases that require positioned params (e.g. PostgreSQL),
+	 *                    a "falsy" value can be used to force resetting the placeholder
+	 *                    count; using boolean 'false' will reset it without actually
+	 *                    returning a placeholder. ADOdb will also automatically reset
+	 *                    the count when executing a query.
 	 * @param string $type (unused)
 	 * @return string query parameter placeholder
 	 */

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -114,6 +114,7 @@ class ADODB_postgres64 extends ADOConnection{
 	var $_bindInputArray = false; // requires postgresql 7.3+ and ability to modify database
 	var $disableBlobs = false; // set to true to disable blob checking, resulting in 2-5% improvement in performance.
 
+	/** @var int $_pnum Number of the last assigned query parameter {@see param()} */
 	var $_pnum = 0;
 
 	// The last (fmtTimeStamp is not entirely correct:
@@ -624,15 +625,18 @@ class ADODB_postgres64 extends ADOConnection{
 
 	}
 
-	function Param($name,$type='C')
+	function param($name, $type='C')
 	{
-		if ($name) {
-			$this->_pnum++;
-		} else {
-			// Reset param num if $name is false
+		if (!$name) {
+			// Reset parameter number if $name is falsy
 			$this->_pnum = 0;
+			if ($name === false) {
+				// and don't return placeholder if false (see #380)
+				return '';
+			}
 		}
-		return '$' . $this->_pnum;
+
+		return '$' . ++$this->_pnum;
 	}
 
 	function MetaIndexes ($table, $primary = FALSE, $owner = false)


### PR DESCRIPTION
Allowing param(false) to reset the query parameter count (see #380,
commit 46fa66c10dc50547167d0f8bbbcb6484edf30d1c) introduced a regression
when a falsy value was used, like `param(0)` in adodb-session2.php.

ADODB_postgres64::param() now differenciates betwen use of:
- falsy value -> reset count and return the first placeholder ($1)
- boolean `false` -> reset count, do not return placeholder (next call
  will return $1).

Updated PHPDoc for parent ADOConnection::param() to reflect this.

Fixes #682, #380