### PR TITLE
mssql: enable _insertID() again

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -496,7 +496,8 @@ if (!defined('_ADODB_LAYER')) {
 	//
 	var $_oldRaiseFn =  false;
 	var $_transOK = null;
-	var $_connectionID	= false;	/// The returned link identifier whenever a successful database connection is made.
+	/** @var resource Identifier for the native database connection */
+	var $_connectionID = false;
 	var $_errorMsg = false;		/// A variable which was used to keep the returned last error message.  The value will
 								/// then returned by the errorMsg() function
 	var $_errorCode = false;	/// Last error code, not guaranteed to be used - only by oci8

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1467,6 +1467,15 @@ if (!defined('_ADODB_LAYER')) {
 	}
 
 	/**
+	 * Enable or disable the Last Insert Id functionality.
+	 *
+	 * If the Driver supports it, this function allows setting {@see $hasInsertID}.
+	 *
+	 * @param bool $enable False to disable
+	 */
+	public function enableLastInsertID($enable = true) {}
+
+	/**
 	 * Return the id of the last row that has been inserted in a table.
 	 *
 	 * @param string $table

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1457,7 +1457,7 @@ if (!defined('_ADODB_LAYER')) {
 			return $this->lastInsID;
 		}
 		if ($this->hasInsertID) {
-			return $this->_insertid($table,$column);
+			return $this->_insertID($table,$column);
 		}
 		if ($this->debug) {
 			ADOConnection::outp( '<p>Insert_ID error</p>');
@@ -1466,6 +1466,18 @@ if (!defined('_ADODB_LAYER')) {
 		return false;
 	}
 
+	/**
+	 * Return the id of the last row that has been inserted in a table.
+	 *
+	 * @param string $table
+	 * @param string $column
+	 *
+	 * @return int|false
+	 */
+	protected function _insertID($table = '', $column = '')
+	{
+		return false;
+	}
 
 	/**
 	 * Portable Insert ID. Pablo Roca <pabloroca#mvps.org>

--- a/drivers/adodb-ado_mssql.inc.php
+++ b/drivers/adodb-ado_mssql.inc.php
@@ -40,7 +40,7 @@ class  ADODB_ado_mssql extends ADODB_ado {
 
 	//var $_inTransaction = 1; // always open recordsets, so no transaction problems.
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 			return $this->GetOne('select SCOPE_IDENTITY()');
 	}

--- a/drivers/adodb-csv.inc.php
+++ b/drivers/adodb-csv.inc.php
@@ -38,7 +38,7 @@ class ADODB_csv extends ADOConnection {
 	var $hasTransactions = false;
 	var $_errorNo = false;
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 		return $this->_insertid;
 	}

--- a/drivers/adodb-db2.inc.php
+++ b/drivers/adodb-db2.inc.php
@@ -92,7 +92,7 @@ class ADODB_db2 extends ADOConnection {
 	
 	function __construct() {}
 
-    function _insertid()
+	protected function _insertID($table = '', $column = '')
     {
         return ADOConnection::GetOne('VALUES IDENTITY_VAL_LOCAL()');
     }

--- a/drivers/adodb-fbsql.inc.php
+++ b/drivers/adodb-fbsql.inc.php
@@ -25,7 +25,7 @@ class ADODB_fbsql extends ADOConnection {
 	var $fmtTimeStamp = "'Y-m-d H:i:s'";
 	var $hasLimit = false;
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 			return fbsql_insert_id($this->_connectionID);
 	}

--- a/drivers/adodb-informix72.inc.php
+++ b/drivers/adodb-informix72.inc.php
@@ -83,7 +83,7 @@ class ADODB_informix72 extends ADOConnection {
 
 
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 		$sqlca =ifx_getsqlca($this->lastQuery);
 		return @$sqlca["sqlerrd1"];

--- a/drivers/adodb-mssql.inc.php
+++ b/drivers/adodb-mssql.inc.php
@@ -110,7 +110,7 @@ class ADODB_mssql extends ADOConnection {
 		return " ISNULL($field, $ifNull) "; // if MS SQL Server
 	}
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 	// SCOPE_IDENTITY()
 	// Returns the last IDENTITY value inserted into an IDENTITY column in

--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -648,8 +648,11 @@ class ADODB_mssqlnative extends ADOConnection {
 		if (!$rez) {
 			$rez = false;
 		} elseif ($retrieveLastInsertID) {
-			// Get the inserted id from the 2nd result
-			if (sqlsrv_next_result($rez) && sqlsrv_fetch($rez)) {
+			// Get the inserted id from the last result
+			// Note: loop is required as server may return more than one row,
+			// e.g. if triggers are involved (see #41)
+			while (sqlsrv_next_result($rez)) {
+				sqlsrv_fetch($rez);
 				$this->lastInsID = sqlsrv_get_field($rez, 0, SQLSRV_PHPTYPE_INT);
 			}
 		}

--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -50,12 +50,13 @@ class ADODB_mssqlnative extends ADOConnection {
 	var $fmtDate = "'Y-m-d'";
 	var $fmtTimeStamp = "'Y-m-d\TH:i:s'";
 	/**
-	 * While the driver does have InsertID capability, the functionality is
-	 * turned off by default for performance reasons.
-	 * Switch it on as needed by calling {@see enableLastInsertID()}.
+	 * Enabling InsertID capability will cause execution of an extra query
+	 * {@see $identitySQL} after each INSERT statement. To improve performance
+	 * when inserting a large number of records, you should switch this off by
+	 * calling {@see enableLastInsertID enableLastInsertID(false)}.
 	 * @var bool $hasInsertID
 	 */
-	var $hasInsertID = false;
+	var $hasInsertID = true;
 	var $substr = "substring";
 	var $length = 'len';
 	var $hasAffectedRows = true;

--- a/drivers/adodb-mysql.inc.php
+++ b/drivers/adodb-mysql.inc.php
@@ -272,7 +272,7 @@ class ADODB_mysql extends ADOConnection {
 		return "'" . str_replace("'", $this->replaceQuote, $s) . "'";
 	}
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 		return ADOConnection::GetOne('SELECT LAST_INSERT_ID()');
 		//return mysql_insert_id($this->_connectionID);

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -400,9 +400,9 @@ class ADODB_mysqli extends ADOConnection {
 	/**
 	 * Return the AUTO_INCREMENT id of the last row that has been inserted or updated in a table.
 	 *
-	 * @return int|string
+	 * @inheritDoc
 	 */
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 		// mysqli_insert_id does not return the last_insert_id if called after
 		// execution of a stored procedure so we execute this instead.

--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -314,20 +314,19 @@ END;
 		return " NVL($field, $ifNull) "; // if Oracle
 	}
 	
-	function _insertid($tabname,$column='')
+	protected function _insertID($table = '', $column = '')
 	{
 		
 		if (!$this->seqField) 
 			return false;
 
-		
-		if ($this->schema) 
+		if ($this->schema)
 		{
-			$t = strpos($tabname,'.');
-			if ($t !== false) 
-				$tab = substr($tabname,$t+1);
-			else 
-				$tab = $tabname;
+			$t = strpos($table,'.');
+			if ($t !== false)
+				$tab = substr($table,$t+1);
+			else
+				$tab = $table;
 			
 			if ($this->useCompactAutoIncrements)
 				$tab = sprintf('%u',crc32(strtolower($tab)));
@@ -337,9 +336,9 @@ END;
 		else 
 		{
 			if ($this->useCompactAutoIncrements)
-				$tabname = sprintf('%u',crc32(strtolower($tabname)));
-			
-			$seqname = $this->seqPrefix.$tabname;
+				$table = sprintf('%u',crc32(strtolower($table)));
+
+			$seqname = $this->seqPrefix.$table;
 		}
 
 		if (strlen($seqname) > 30)

--- a/drivers/adodb-odbc_db2.inc.php
+++ b/drivers/adodb-odbc_db2.inc.php
@@ -131,7 +131,7 @@ class ADODB_ODBC_DB2 extends ADODB_odbc {
 		return array('description'=>'DB2 ODBC driver', 'version'=>$vers);
 	}
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 		return $this->GetOne($this->identitySQL);
 	}

--- a/drivers/adodb-odbc_mssql.inc.php
+++ b/drivers/adodb-odbc_mssql.inc.php
@@ -66,7 +66,7 @@ class  ADODB_odbc_mssql extends ADODB_odbc {
 		return " ISNULL($field, $ifNull) "; // if MS SQL Server
 	}
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 	// SCOPE_IDENTITY()
 	// Returns the last IDENTITY value inserted into an IDENTITY column in

--- a/drivers/adodb-odbtp.inc.php
+++ b/drivers/adodb-odbtp.inc.php
@@ -76,7 +76,7 @@ class ADODB_odbtp extends ADOConnection{
 	}
 */
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 	// SCOPE_IDENTITY()
 	// Returns the last IDENTITY value inserted into an IDENTITY column in

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -615,7 +615,7 @@ class ADODB_pdo extends ADOConnection {
 		return ($this->_stmt) ? $this->_stmt->rowCount() : 0;
 	}
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 		return ($this->_connectionID) ? $this->_connectionID->lastInsertId() : 0;
 	}

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -183,8 +183,10 @@ class ADODB_postgres64 extends ADOConnection{
 	 * Using a OID as a unique identifier is not generally wise.
 	 * Unless you are very careful, you might end up with a tuple having
 	 * a different OID if a database must be reloaded.
+	 *
+	 * @inheritDoc
 	 */
-	function _insertid($table,$column)
+	protected function _insertID($table = '', $column = '')
 	{
 		if (!is_resource($this->_resultid) || get_resource_type($this->_resultid) !== 'pgsql result') return false;
 		$oid = pg_last_oid($this->_resultid);

--- a/drivers/adodb-postgres8.inc.php
+++ b/drivers/adodb-postgres8.inc.php
@@ -37,7 +37,7 @@ class ADODB_postgres8 extends ADODB_postgres7
 	 * @return int last inserted ID for given table/column, or the most recently
 	 *             returned one if $table or $column are empty
 	 */
-	function _insertid($table, $column)
+	protected function _insertID($table = '', $column = '')
 	{
 		return empty($table) || empty($column)
 			? $this->GetOne("SELECT lastval()")

--- a/drivers/adodb-sapdb.inc.php
+++ b/drivers/adodb-sapdb.inc.php
@@ -144,7 +144,7 @@ class ADODB_SAPDB extends ADODB_odbc {
 	}
 
 	// unlike it seems, this depends on the db-session and works in a multiuser environment
-	function _insertid($table,$column)
+	protected function _insertID($table = '', $column = '')
 	{
 		return empty($table) ? False : $this->GetOne("SELECT $table.CURRVAL FROM DUAL");
 	}

--- a/drivers/adodb-sqlanywhere.inc.php
+++ b/drivers/adodb-sqlanywhere.inc.php
@@ -58,9 +58,10 @@ if (!defined('ADODB_SYBASE_SQLANYWHERE')){
   	var $databaseType = "sqlanywhere";
 	var $hasInsertID = true;
 
-	 function _insertid() {
-  	   return $this->GetOne('select @@identity');
-	 }
+	protected function _insertID($table = '', $column = '')
+	{
+		return $this->GetOne('select @@identity');
+	}
 
   function create_blobvar($blobVarName) {
    $this->Execute("create variable $blobVarName long binary");

--- a/drivers/adodb-sqlite.inc.php
+++ b/drivers/adodb-sqlite.inc.php
@@ -132,7 +132,7 @@ class ADODB_sqlite extends ADOConnection {
 		$parentDriver->hasInsertID = true;
 	}
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 		return sqlite_last_insert_rowid($this->_connectionID);
 	}

--- a/drivers/adodb-sqlite3.inc.php
+++ b/drivers/adodb-sqlite3.inc.php
@@ -253,7 +253,7 @@ class ADODB_sqlite3 extends ADOConnection {
 		$parentDriver->hasInsertID = true;
 	}
 
-	function _insertid()
+	protected function _insertID($table = '', $column = '')
 	{
 		return $this->_connectionID->lastInsertRowID();
 	}

--- a/drivers/adodb-sybase.inc.php
+++ b/drivers/adodb-sybase.inc.php
@@ -44,11 +44,15 @@ class ADODB_sybase extends ADOConnection {
 
 	var $port;
 
-	// might require begintrans -- committrans
-	function _insertid()
+	/**
+	 * might require begintrans -- committrans
+	 * @inheritDoc
+	 */
+	protected function _insertID($table = '', $column = '')
 	{
 		return $this->GetOne('select @@identity');
 	}
+
 	  // might require begintrans -- committrans
 	function _affectedrows()
 	{

--- a/drivers/adodb-text.inc.php
+++ b/drivers/adodb-text.inc.php
@@ -97,11 +97,6 @@ class ADODB_text extends ADOConnection {
 		return sizeof($this->_origarray);
 	}
 
-	function _insertid()
-	{
-			return false;
-	}
-
 	function _affectedrows()
 	{
 			return false;


### PR DESCRIPTION
In ADOdb 5.21.0, for performance reasons [1] the _query() method no
longer retrieves the last inserted Id.

This introduced a regression, as it was only possible to retrieve the
Insert Id for "normal" queries, but not parameterized ones as
Insert_ID() always returned null in this case.

To maintain the driver's performance, we now allow the client to
decide whether insert queries should execute the extra SCOPE_IDENTITY()
call, by providing a new enableLastInsertID() method.

Fixes #692

[1]: https://github.com/ADOdb/ADOdb/issues/185#issuecomment-169057606
