### PR TITLE
Handle invalid connection parameters in ADODB_mysqli::_connect()

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -537,7 +537,12 @@ if (!defined('_ADODB_LAYER')) {
 	 * Adds a parameter to the connection string.
 	 *
 	 * Parameters must be added before the connection is established;
-	 * they are then passed on to the connect statement.
+	 * they are then passed on to the connect statement, which will.
+	 * process them if the driver supports this feature.
+	 *
+	 * Example usage:
+	 * - mssqlnative: setConnectionParameter('CharacterSet','UTF-8');
+	 * - mysqli: setConnectionParameter(MYSQLI_SET_CHARSET_NAME,'utf8mb4');
 	 *
 	 * If used in a portable environment, parameters set in this manner should
 	 * be predicated on the database provider, as unexpected results may occur
@@ -545,13 +550,9 @@ if (!defined('_ADODB_LAYER')) {
 	 *
 	 * @param string $parameter The name of the parameter to set
 	 * @param string $value     The value of the parameter
-	 *
-	 * @return null
-	 *
-	 * @example, for mssqlnative driver ('CharacterSet','UTF-8')
 	 */
 	public function setConnectionParameter($parameter, $value) {
-		$this->connectionParameters[] = array($parameter => $value);
+		$this->connectionParameters[] = array($parameter=>$value);
 	}
 
 	/**

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -509,6 +509,19 @@ if (!defined('_ADODB_LAYER')) {
 	var $_logsql = false;
 	var $_transmode = ''; // transaction mode
 
+	/**
+	 * Additional parameters that may be passed to drivers in the connect string.
+	 *
+	 * Data is stored as an array of arrays and not a simple associative array,
+	 * because some drivers (e.g. mysql) allow multiple parameters with the same
+	 * key to be set.
+	 * @link https://github.com/ADOdb/ADOdb/issues/187
+	 *
+	 * @see setConnectionParameter()
+	 *
+	 * @var array $connectionParameters Set of ParameterName => Value pairs
+	 */
+	protected $connectionParameters = array();
 
 	/**
 	 * Default Constructor.
@@ -519,12 +532,6 @@ if (!defined('_ADODB_LAYER')) {
 	public function __construct()
 	{
 	}
-
-	/*
-	 * Additional parameters that may be passed to drivers in the connect string
-	 * Driver must be coded to accept the parameters
-	 */
-	protected $connectionParameters = array();
 
 	/**
 	 * Adds a parameter to the connection string.

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -550,9 +550,12 @@ if (!defined('_ADODB_LAYER')) {
 	 *
 	 * @param string $parameter The name of the parameter to set
 	 * @param string $value     The value of the parameter
+	 *
+	 * @return bool True if success, false otherwise (e.g. parameter is not valid)
 	 */
 	public function setConnectionParameter($parameter, $value) {
 		$this->connectionParameters[] = array($parameter=>$value);
+		return true;
 	}
 
 	/**

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -864,15 +864,15 @@ class ADODB_mysqli extends ADOConnection {
 		* Return assoc array where key is column name, value is column type
 		*    [1] => int unsigned
 		*/
-		
-		$SQL = "SELECT column_name, column_type 
-				  FROM information_schema.columns 
-				 WHERE table_schema='{$this->databaseName}' 
+
+		$SQL = "SELECT column_name, column_type
+				  FROM information_schema.columns
+				 WHERE table_schema='{$this->databaseName}'
 				   AND table_name='$table'";
-		
+
 		$schemaArray = $this->getAssoc($SQL);
 		$schemaArray = array_change_key_case($schemaArray,CASE_LOWER);
-	
+
 		$rs = $this->Execute(sprintf($this->metaColumnsSQL,$table));
 		if (isset($savem)) $this->SetFetchMode($savem);
 		$ADODB_FETCH_MODE = $save;
@@ -884,7 +884,7 @@ class ADODB_mysqli extends ADOConnection {
 			$fld = new ADOFieldObject();
 			$fld->name = $rs->fields[0];
 			$type = $rs->fields[1];
-			
+
 			/*
 			* Type from information_schema returns
 			* the same format in V8 mysql as V5
@@ -910,7 +910,7 @@ class ADODB_mysqli extends ADOConnection {
 				$fld->type = $type;
 				$fld->max_length = -1;
 			}
-			
+
 			$fld->not_null = ($rs->fields[2] != 'YES');
 			$fld->primary_key = ($rs->fields[3] == 'PRI');
 			$fld->auto_increment = (strpos($rs->fields[5], 'auto_increment') !== false);

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -160,13 +160,15 @@ class ADODB_mysqli extends ADOConnection {
 			mysqli_options($this->_connectionID,$arr[0],$arr[1]);
 		}
 
-		/*
-		* Now merge in the standard connection parameters setting
-		*/
-		foreach ($this->connectionParameters as $options)
-		{
-			foreach($options as $k=>$v)
-				$ok = mysqli_options($this->_connectionID,$k,$v);
+		// Now merge in the standard connection parameters setting
+		foreach ($this->connectionParameters as $parameter => $value) {
+			// Make sure parameter is numeric before calling mysqli_options()
+			// that to avoid Warning (or TypeError exception on PHP 8).
+			if (!is_numeric($parameter)
+				|| !mysqli_options($this->_connectionID, $parameter, $value)
+			) {
+				$this->outp_throw("Invalid connection parameter '$parameter'", __METHOD__);
+			}
 		}
 
 		//https://php.net/manual/en/mysqli.persistconns.php

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -98,6 +98,27 @@ class ADODB_mysqli extends ADOConnection {
 	}
 
 	/**
+	 * Adds a parameter to the connection string.
+	 *
+	 * Parameter must be one of the the constants listed in mysqli_options().
+	 * @see https://www.php.net/manual/en/mysqli.options.php
+	 *
+	 * @param int $parameter The parameter to set
+	 * @param string $value The value of the parameter
+	 *
+	 * @example, for mssqlnative driver ('CharacterSet','UTF-8')
+	 * @return bool
+	 */
+	public function setConnectionParameter($parameter, $value) {
+		if(!is_numeric($parameter)) {
+			$this->outp_throw("Invalid connection parameter '$parameter'", __METHOD__);
+			return false;
+		}
+		$this->connectionParameters[$parameter] = $value;
+		return true;
+	}
+
+	/**
 	 * Connect to a database.
 	 *
 	 * @todo add: parameter int $port, parameter string $socket


### PR DESCRIPTION
- avoid PHP Warning / TypeErrors when parameter is invalid (string or unknown option Id)
- catch error early by overriding setConnectionParameter()

Also improves PHPDoc and fixes a few whitespace issues.

Fixes #693