### PR TITLE
Fixed function declaration to match parent

### DIFF
--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -273,10 +273,10 @@ class ADODB_pdo extends ADOConnection {
 		return $this->_driver->MetaColumns($table,$normalize);
 	}
 
-	public function metaIndexes($table,$normalize=true)
+	public function metaIndexes($table,$normalize=true,$owner=false)
 	{
 		if (method_exists($this->_driver,'metaIndexes'))
-			return $this->_driver->metaIndexes($table,$normalize);
+			return $this->_driver->metaIndexes($table,$normalize,$owner);
 	}
 
 	/**


### PR DESCRIPTION
Fixed message "Declaration of ADODB_pdo::metaIndexes($table, $normalize = true) should be compatible with ADOConnection::MetaIndexes($table, $primary = false, $owner = false)"