### PR TITLE
Affected_rows returns number instead of false see #604

### DIFF
--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -76,6 +76,12 @@ class ADODB_mysqli extends ADOConnection {
 	 */
 	private $usePreparedStatement = false;
 	private $useLastInsertStatement = false;
+	
+	/*
+	* Set by _query to flag if the last executed statement
+	* is a SELECT
+	*/
+	private $isSelectStatement = false;
 
 	/**
 	 * Sets the isolation level of a transaction.
@@ -429,6 +435,14 @@ class ADODB_mysqli extends ADOConnection {
 	 */
 	function _affectedrows()
 	{
+		
+		if ($this->isSelectStatement)
+			/*
+			* Affected rows works fine against selects, returning
+			* the rowcount, but ADOdb does not do that.
+			*/
+			return false;
+
 		$result =  @mysqli_affected_rows($this->_connectionID);
 		if ($result == -1) {
 			if ($this->debug) ADOConnection::outp("mysqli_affected_rows() failed : "  . $this->errorMsg());
@@ -1110,7 +1124,7 @@ class ADODB_mysqli extends ADOConnection {
 
 		return $mysql_res;
 		*/
-
+		
 		if ($this->multiQuery) {
 			$rs = mysqli_multi_query($this->_connectionID, $sql.';');
 			if ($rs) {
@@ -1119,8 +1133,17 @@ class ADODB_mysqli extends ADOConnection {
 			}
 		} else {
 			$rs = mysqli_query($this->_connectionID, $sql, $ADODB_COUNTRECS ? MYSQLI_STORE_RESULT : MYSQLI_USE_RESULT);
-
-			if ($rs) return $rs;
+			if ($rs){
+				if (is_object($rs))
+				{
+					$this->isSelectStatement = true;
+				}
+				else
+				{
+					$this->isSelectStatement = false;
+				}
+				return $rs;
+			}
 		}
 
 		if($this->debug)


### PR DESCRIPTION
The mysql affected rows returns a valid value when used against a SELECT statement. This does not conform to the ADOdb standard which requires it to return false