### PR TITLE
Add postgresql supported versions to $requiresAliasArray

### DIFF
--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -330,7 +330,7 @@ function _adodb_getcount(&$zthis, $sql,$inputarr=false,$secs2cache=0)
 	* statement to have an alias for the result
 	*/
 	$requiresAlias = '';
-	$requiresAliasArray = array('postgres','mysql','mysqli','mssql','mssqlnative','sqlsrv');
+	$requiresAliasArray = array('postgres','postgres6','postgres7','postgres8','postgres9','mysql','mysqli','mssql','mssqlnative','sqlsrv');
 	if (in_array($zthis->databaseType,$requiresAliasArray)
 		|| in_array($zthis->dsnType,$requiresAliasArray)
 	) {


### PR DESCRIPTION
In _adodb_getcount function
allow to use Alias in sql for postgresql (better performance)
fix issue https://github.com/ADOdb/ADOdb/issues/735