### PR TITLE
mysql: Handle tables that are reserved words

### DIFF
--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -565,7 +565,7 @@ class ADODB_mysqli extends ADOConnection {
 		}
 
 		// get index details
-		$rs = $this->execute(sprintf('SHOW INDEXES FROM %s',$table));
+		$rs = $this->Execute(sprintf('SHOW INDEXES FROM `%s`',$table));
 
 		// restore fetchmode
 		if (isset($savem)) {
@@ -847,7 +847,7 @@ class ADODB_mysqli extends ADOConnection {
 			$table = "$owner.$table";
 		}
 
-		$a_create_table = $this->getRow(sprintf('SHOW CREATE TABLE %s', $table));
+		$a_create_table = $this->getRow(sprintf('SHOW CREATE TABLE `%s`', $table));
 
 		$this->setFetchMode($savem);
 


### PR DESCRIPTION
Wrapping table names represented by `%s` in backticks so tables names that are also reserved words don't cause issues.

These 2 locations have impacted our project.  There are more in this file but they have not impacted us yet so I have left them untouched.

I also updated the call to `$this->Execute()` in the first case.  PHP is case insensitive to this, but not all IDE's are so this should help those.