### PR TITLE
is_array() is expensive

### DIFF
--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -1009,6 +1009,10 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 
 	function _fixblobs()
 	{
+		// Check prerequisites and bail early if we do not have what we need.
+		if (!isset($this->_blobArr)) return false;
+		if ($this->fields === false) return false;
+
 		if ($this->fetchMode == PGSQL_NUM || $this->fetchMode == PGSQL_BOTH) {
 			foreach($this->_blobArr as $k => $v) {
 				$this->fields[$k] = ADORecordSet_postgres64::_decode($this->fields[$k]);
@@ -1019,6 +1023,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 				$this->fields[$v] = ADORecordSet_postgres64::_decode($this->fields[$v]);
 			}
 		}
+		return true;
 	}
 
 	// 10% speedup to move MoveNext to child class
@@ -1028,10 +1033,8 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 			$this->_currentRow++;
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
 				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
-				if (is_array($this->fields) && $this->fields) {
-					if (isset($this->_blobArr)) $this->_fixblobs();
-					return true;
-				}
+				$this->_fixblobs();
+				if ($this->fields !== false) return true;
 			}
 			$this->fields = false;
 			$this->EOF = true;
@@ -1046,8 +1049,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 			return false;
 
 		$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
-
-		if ($this->fields && isset($this->_blobArr)) $this->_fixblobs();
+		$this->_fixblobs();
 
 		return (is_array($this->fields));
 	}

--- a/drivers/adodb-postgres7.inc.php
+++ b/drivers/adodb-postgres7.inc.php
@@ -336,10 +336,8 @@ class ADORecordSet_postgres7 extends ADORecordSet_postgres64{
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
 				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
 
-				if ($this->fields !== false) {
-					if (isset($this->_blobArr)) $this->_fixblobs();
-					return true;
-				}
+				$this->_fixblobs();
+				if ($this->fields !== false) return true;
 			}
 			$this->fields = false;
 			$this->EOF = true;
@@ -362,10 +360,7 @@ class ADORecordSet_assoc_postgres7 extends ADORecordSet_postgres64{
 
 		$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
 
-		if ($this->fields) {
-			if (isset($this->_blobArr)) $this->_fixblobs();
-			$this->_updatefields();
-		}
+		if ($this->_fixblobs()) $this->_updatefields();
 
 		return (is_array($this->fields));
 	}
@@ -377,16 +372,12 @@ class ADORecordSet_assoc_postgres7 extends ADORecordSet_postgres64{
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
 				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
 
-				if (is_array($this->fields)) {
-					if ($this->fields) {
-						if (isset($this->_blobArr)) $this->_fixblobs();
-
-						$this->_updatefields();
-					}
+				$this->_fixblobs();
+				if ($this->fields !== false) {
+					$this->_updatefields();
 					return true;
 				}
 			}
-
 
 			$this->fields = false;
 			$this->EOF = true;

--- a/drivers/adodb-postgres7.inc.php
+++ b/drivers/adodb-postgres7.inc.php
@@ -336,8 +336,8 @@ class ADORecordSet_postgres7 extends ADORecordSet_postgres64{
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
 				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
 
-				if (is_array($this->fields)) {
-					if ($this->fields && isset($this->_blobArr)) $this->_fixblobs();
+				if ($this->fields !== false) {
+					if (isset($this->_blobArr)) $this->_fixblobs();
 					return true;
 				}
 			}


### PR DESCRIPTION
The call to `pg_fetch_array()` returns `false` in all cases where we wouldn't need or want to potentially `_fixblobs()` and return `true`.

A straight up boolean check is all that is needed here.
