### PR TITLE
Ensure temp $ADODB_COUNTRECS changes really are temporary

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1672,17 +1672,19 @@ if (!defined('_ADODB_LAYER')) {
 		// 0 to offset-1 which will be discarded anyway. So we disable $ADODB_COUNTRECS.
 		global $ADODB_COUNTRECS;
 
-		$savec = $ADODB_COUNTRECS;
-		$ADODB_COUNTRECS = false;
+		try {
+			$savec = $ADODB_COUNTRECS;
+			$ADODB_COUNTRECS = false;
 
-
-		if ($secs2cache != 0) {
-			$rs = $this->CacheExecute($secs2cache,$sql,$inputarr);
-		} else {
-			$rs = $this->Execute($sql,$inputarr);
+			if ($secs2cache != 0) {
+				$rs = $this->CacheExecute($secs2cache, $sql, $inputarr);
+			} else {
+				$rs = $this->Execute($sql, $inputarr);
+			}
+		} finally {
+			$ADODB_COUNTRECS = $savec;
 		}
 
-		$ADODB_COUNTRECS = $savec;
 		if ($rs && !$rs->EOF) {
 			$rs = $this->_rs2rs($rs,$nrows,$offset);
 		}
@@ -1829,11 +1831,15 @@ if (!defined('_ADODB_LAYER')) {
 	public function GetOne($sql, $inputarr=false) {
 		global $ADODB_COUNTRECS,$ADODB_GETONE_EOF;
 
-		$crecs = $ADODB_COUNTRECS;
-		$ADODB_COUNTRECS = false;
+		try {
+			$crecs = $ADODB_COUNTRECS;
+			$ADODB_COUNTRECS = false;
+			$rs = $this->Execute($sql, $inputarr);
+		} finally {
+			$ADODB_COUNTRECS = $crecs;
+		}
 
 		$ret = false;
-		$rs = $this->Execute($sql,$inputarr);
 		if ($rs) {
 			if ($rs->EOF) {
 				$ret = $ADODB_GETONE_EOF;
@@ -1843,7 +1849,6 @@ if (!defined('_ADODB_LAYER')) {
 
 			$rs->Close();
 		}
-		$ADODB_COUNTRECS = $crecs;
 		return $ret;
 	}
 
@@ -1972,10 +1977,14 @@ if (!defined('_ADODB_LAYER')) {
 	function GetArray($sql,$inputarr=false) {
 		global $ADODB_COUNTRECS;
 
-		$savec = $ADODB_COUNTRECS;
-		$ADODB_COUNTRECS = false;
-		$rs = $this->Execute($sql,$inputarr);
-		$ADODB_COUNTRECS = $savec;
+		try {
+			$savec = $ADODB_COUNTRECS;
+			$ADODB_COUNTRECS = false;
+			$rs = $this->Execute($sql, $inputarr);
+		} finally {
+			$ADODB_COUNTRECS = $savec;
+		}
+
 		if (!$rs)
 			if (defined('ADODB_PEAR')) {
 				return ADODB_PEAR_Error();
@@ -1994,10 +2003,13 @@ if (!defined('_ADODB_LAYER')) {
 	function CacheGetArray($secs2cache,$sql=false,$inputarr=false) {
 		global $ADODB_COUNTRECS;
 
-		$savec = $ADODB_COUNTRECS;
-		$ADODB_COUNTRECS = false;
-		$rs = $this->CacheExecute($secs2cache,$sql,$inputarr);
-		$ADODB_COUNTRECS = $savec;
+		try {
+			$savec = $ADODB_COUNTRECS;
+			$ADODB_COUNTRECS = false;
+			$rs = $this->CacheExecute($secs2cache, $sql, $inputarr);
+		} finally {
+			$ADODB_COUNTRECS = $savec;
+		}
 
 		if (!$rs)
 			if (defined('ADODB_PEAR')) {
@@ -2028,12 +2040,14 @@ if (!defined('_ADODB_LAYER')) {
 	function GetRow($sql,$inputarr=false) {
 		global $ADODB_COUNTRECS;
 
-		$crecs = $ADODB_COUNTRECS;
-		$ADODB_COUNTRECS = false;
+		try {
+			$crecs = $ADODB_COUNTRECS;
+			$ADODB_COUNTRECS = false;
+			$rs = $this->Execute($sql, $inputarr);
+		} finally {
+			$ADODB_COUNTRECS = $crecs;
+		}
 
-		$rs = $this->Execute($sql,$inputarr);
-
-		$ADODB_COUNTRECS = $crecs;
 		if ($rs) {
 			if (!$rs->EOF) {
 				$arr = $rs->fields;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,8 +18,10 @@ Older changelogs:
 
 ### Fixed
 
+- mysqli: force error reporting mode to OFF (PHP 8.1 compatibility) 
+  [#755](https://github.com/ADOdb/ADOdb/issues/755)
 - pdo: fix metaIndexes declaration to match parent
-  [#717](https://github.com/ADOdb/ADOdb/issues/749)
+  [#717](https://github.com/ADOdb/ADOdb/issues/717)
 
 
 ## [5.21.2] - 2021-08-22

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,8 @@ Older changelogs:
 
 ### Fixed
 
+- core: Ensure temp $ADODB_COUNTRECS changes really are temporary
+  [#761](https://github.com/ADOdb/ADOdb/issues/761)
 - mysqli: force error reporting mode to OFF (PHP 8.1 compatibility) 
   [#755](https://github.com/ADOdb/ADOdb/issues/755)
 - pdo: fix metaIndexes declaration to match parent

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -81,11 +81,24 @@ class ADODB_mysqli extends ADOConnection {
 	 */
 	private $usePreparedStatement = false;
 	private $useLastInsertStatement = false;
-	
+
 	/**
 	 * @var bool True if the last executed statement is a SELECT {@see _query()}
 	 */
 	private $isSelectStatement = false;
+
+	/**
+	 * ADODB_mysqli constructor.
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+
+		// Forcing error reporting mode to OFF, which is no longer the default
+		// starting with PHP 8.1 (see #755)
+		mysqli_report(MYSQLI_REPORT_OFF);
+	}
+
 
 	/**
 	 * Sets the isolation level of a transaction.
@@ -1126,7 +1139,7 @@ class ADODB_mysqli extends ADOConnection {
 
 		return $mysql_res;
 		*/
-		
+
 		if ($this->multiQuery) {
 			$rs = mysqli_multi_query($this->_connectionID, $sql.';');
 			if ($rs) {


### PR DESCRIPTION
Add try/finally blocks in selectLimit(), getOne(), getRow(), getArray()
and cacheGetArray() methods when temporarily changing $ADODB_COUNTRECS
global's value, to ensure it is correctly restored to its previous value
when the execute() call triggers an exception.

Fixes #761