### PR TITLE
Refactored `_fixblobs()`

### DIFF
--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -1009,6 +1009,10 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 
 	function _fixblobs()
 	{
+		// Check prerequisites and bail early if we do not have what we need.
+		if (!isset($this->_blobArr)) return false;
+		if ($this->fields === false) return false;
+
 		if ($this->fetchMode == PGSQL_NUM || $this->fetchMode == PGSQL_BOTH) {
 			foreach($this->_blobArr as $k => $v) {
 				$this->fields[$k] = ADORecordSet_postgres64::_decode($this->fields[$k]);
@@ -1019,6 +1023,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 				$this->fields[$v] = ADORecordSet_postgres64::_decode($this->fields[$v]);
 			}
 		}
+		return true;
 	}
 
 	// 10% speedup to move MoveNext to child class
@@ -1028,10 +1033,8 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 			$this->_currentRow++;
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
 				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
-				if (is_array($this->fields) && $this->fields) {
-					if (isset($this->_blobArr)) $this->_fixblobs();
-					return true;
-				}
+				$this->_fixblobs();
+				if ($this->fields !== false) return true;
 			}
 			$this->fields = false;
 			$this->EOF = true;
@@ -1046,8 +1049,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 			return false;
 
 		$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
-
-		if ($this->fields && isset($this->_blobArr)) $this->_fixblobs();
+		$this->_fixblobs();
 
 		return (is_array($this->fields));
 	}

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -1007,6 +1007,12 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 		return pg_unescape_bytea($blob);
 	}
 
+	function _prepfields()
+	{
+		$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
+		return $this->_fixblobs();
+	}
+
 	function _fixblobs()
 	{
 		// Check prerequisites and bail early if we do not have what we need.
@@ -1032,8 +1038,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 		if (!$this->EOF) {
 			$this->_currentRow++;
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
-				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
-				$this->_fixblobs();
+				$this->_prepfields();
 				if ($this->fields !== false) return true;
 			}
 			$this->fields = false;
@@ -1048,8 +1053,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 		if ($this->_currentRow >= $this->_numOfRows && $this->_numOfRows >= 0)
 			return false;
 
-		$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
-		$this->_fixblobs();
+		$this->_prepfields();
 
 		return (is_array($this->fields));
 	}

--- a/drivers/adodb-postgres7.inc.php
+++ b/drivers/adodb-postgres7.inc.php
@@ -334,9 +334,7 @@ class ADORecordSet_postgres7 extends ADORecordSet_postgres64{
 		if (!$this->EOF) {
 			$this->_currentRow++;
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
-				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
-
-				$this->_fixblobs();
+				$this->_prepfields();
 				if ($this->fields !== false) return true;
 			}
 			$this->fields = false;
@@ -358,9 +356,7 @@ class ADORecordSet_assoc_postgres7 extends ADORecordSet_postgres64{
 			return false;
 		}
 
-		$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
-
-		if ($this->_fixblobs()) $this->_updatefields();
+		if ($this->_prepfields()) $this->_updatefields();
 
 		return (is_array($this->fields));
 	}
@@ -370,9 +366,7 @@ class ADORecordSet_assoc_postgres7 extends ADORecordSet_postgres64{
 		if (!$this->EOF) {
 			$this->_currentRow++;
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
-				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
-
-				$this->_fixblobs();
+				$this->_prepfields();
 				if ($this->fields !== false) {
 					$this->_updatefields();
 					return true;

--- a/drivers/adodb-postgres7.inc.php
+++ b/drivers/adodb-postgres7.inc.php
@@ -336,10 +336,8 @@ class ADORecordSet_postgres7 extends ADORecordSet_postgres64{
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
 				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
 
-				if ($this->fields !== false) {
-					if (isset($this->_blobArr)) $this->_fixblobs();
-					return true;
-				}
+				$this->_fixblobs();
+				if ($this->fields !== false) return true;
 			}
 			$this->fields = false;
 			$this->EOF = true;
@@ -362,10 +360,7 @@ class ADORecordSet_assoc_postgres7 extends ADORecordSet_postgres64{
 
 		$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
 
-		if ($this->fields) {
-			if (isset($this->_blobArr)) $this->_fixblobs();
-			$this->_updatefields();
-		}
+		if ($this->_fixblobs()) $this->_updatefields();
 
 		return (is_array($this->fields));
 	}
@@ -377,16 +372,12 @@ class ADORecordSet_assoc_postgres7 extends ADORecordSet_postgres64{
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
 				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
 
-				if (is_array($this->fields)) {
-					if ($this->fields) {
-						if (isset($this->_blobArr)) $this->_fixblobs();
-
-						$this->_updatefields();
-					}
+				$this->_fixblobs();
+				if ($this->fields !== false) {
+					$this->_updatefields();
 					return true;
 				}
 			}
-
 
 			$this->fields = false;
 			$this->EOF = true;

--- a/drivers/adodb-postgres7.inc.php
+++ b/drivers/adodb-postgres7.inc.php
@@ -336,8 +336,8 @@ class ADORecordSet_postgres7 extends ADORecordSet_postgres64{
 			if ($this->_numOfRows < 0 || $this->_numOfRows > $this->_currentRow) {
 				$this->fields = @pg_fetch_array($this->_queryID,$this->_currentRow,$this->fetchMode);
 
-				if (is_array($this->fields)) {
-					if ($this->fields && isset($this->_blobArr)) $this->_fixblobs();
+				if ($this->fields !== false) {
+					if (isset($this->_blobArr)) $this->_fixblobs();
 					return true;
 				}
 			}


### PR DESCRIPTION
The call to `pg_fetch_array()` returns `false` in all cases where we would not need or want to potentially `_fixblobs()` and return `true`.

A straight up boolean check is all that is needed here.

Tracking through `_fixblobs()` is called in a number of places (thanks for the pointer @dregad) and how it is checked for was repeated in every case.  The checks were moved into `_fixblobs()`.

It was also noted that in every case the setting of `$this->fields` was identical as well.  `_prepfields()` was added which sets `$this->fields` and calls `_fixblobs()`.

All instances of `_fixblobs` was replaced with `_prepfields()` and the `pg_fetch_array()` call deleted.

If this is used it would supersede #760 