### PR TITLE
standardize caching of properties of ADORecordSet class #747

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -3899,6 +3899,14 @@ class ADORecordSet implements IteratorAggregate {
 	 */
 	protected $fieldObjectsCache;
 
+	/*
+	* Indicates if the fieldObjects have been retrieved. Prevents
+	* multiple attempts even if the feature is unavailable
+	* @var bool 
+	* @see init()
+	*/
+	protected $fieldObjectsRetrieved;
+
 	/**
 	 * Constructor
 	 *
@@ -3948,8 +3956,18 @@ class ADORecordSet implements IteratorAggregate {
 
 	/**
 	 * Recordset initialization stub
+	 * 
+	 * @return voide
 	 */
-	protected function _initRS() {}
+	protected function _initrs() {}
+
+	/**
+	 * Abstract Stub to set column information in the Recordset field objects cache
+	 *
+	 * @param int		$fieldOffset
+	 * @return object 	containing field information
+	 */
+	protected function setFieldObjectsCache($fieldOffset = -1) {}
 
 	/**
 	 * Row fetch stub

--- a/drivers/adodb-db2.inc.php
+++ b/drivers/adodb-db2.inc.php
@@ -1858,25 +1858,13 @@ class ADORecordSet_db2 extends ADORecordSet {
 		$this->_queryID = $id;
 	}
 
-
-	// returns the field object
-	function fetchField($offset = 0)
-	{
-		$o			   = new ADOFieldObject();
-		$o->name 	   = @db2_field_name($this->_queryID,$offset);
-		$o->type 	   = @db2_field_type($this->_queryID,$offset);
-		$o->max_length = @db2_field_width($this->_queryID,$offset);
-
-		/*
-		if (ADODB_ASSOC_CASE == 0)
-			$o->name = strtolower($o->name);
-		else if (ADODB_ASSOC_CASE == 1)
-			$o->name = strtoupper($o->name);
-		*/
-		return $o;
-	}
-
-	/* Use associative array to get fields array */
+	/*
+	* Use associative array to get fields array 
+	 *
+	 * @param string $colname
+	 * 
+	 * @return ADOFieldObject
+	 */
 	function fields($colname)
 	{
 
@@ -1895,7 +1883,11 @@ class ADORecordSet_db2 extends ADORecordSet {
 		 return $this->fields[$this->bind[strtoupper($colname)]];
 	}
 
-
+	/**
+	 * Initializes Recordset and metadata
+	 *
+	 * @return void
+	 */
 	function _initrs()
 	{
 		global $ADODB_COUNTRECS;
@@ -1907,6 +1899,66 @@ class ADORecordSet_db2 extends ADORecordSet {
 
 		if ($this->_numOfRows == 0)
 			$this->_numOfRows = -1;
+
+		$this->_fetchField();
+
+	}
+
+	/**
+	 * Get column information in the Recordset object.
+	 * fetchField() can be used in order to obtain information about fields
+	 * in a certain query result. If the field offset isn't specified, the next
+	 * field that wasn't yet retrieved by fetchField() is retrieved
+	 *
+	 * @param int		$fieldOffset
+	 * @return object 	containing field information
+	 */
+	protected function _fetchField($fieldOffset = -1)
+	{
+		
+		if ($this->fieldObjectsRetrieved) {
+			if ($this->fieldObjectsCache) {
+				// Already got the information
+				if ($fieldOffset == -1) {
+					return $this->fieldObjectsCache;
+				} else {
+					return $this->fieldObjectsCache[$fieldOffset];
+				}
+			} else {
+				// No metadata available
+				return false;
+			}
+		}
+
+
+		$this->fieldObjectsCache = array();
+		$max = $this->_numOfFields;
+		for ($i=0;$i<$max; $i++)
+		{
+				
+			$o			   = new ADOFieldObject();
+			$o->name 	   = @db2_field_name($this->_queryID,$offset);
+			$o->type 	   = @db2_field_type($this->_queryID,$offset);
+			$o->max_length = @db2_field_width($this->_queryID,$offset);
+			
+			$this->fieldObjectsCache[] = $o;
+
+		}
+		$this->fieldObjectsRetrieved = true;
+
+	}
+
+	/**
+	 * Returns the metadata for a specific field
+	 * 
+	 * @param integer $fieldOffset
+	 * 
+	 * @return bool|ADOFieldObject
+	 */
+	function fetchField($fieldOffset = -1)
+	{
+		if (array_key_exists($fieldOffset,$this->fieldObjectsCache))
+			return $this->fieldObjectsCache[$fieldOffset];
 	}
 
 	function _seek($row)

--- a/drivers/adodb-firebird.inc.php
+++ b/drivers/adodb-firebird.inc.php
@@ -1050,10 +1050,10 @@ class ADORecordset_firebird extends ADORecordSet
 	 * the next field that wasn't yet retrieved by fetchField()
 	 * is retrieved.
 	 *
-	 * $param int $fieldOffset (optional default=-1 for all
+	 * @param int $fieldOffset (optional default=-1 for all
 	 * @return mixed an ADOFieldObject, or array of objects
 	 */
-	private function _fetchField($fieldOffset = -1)
+	protected function _fetchField($fieldOffset = -1)
 	{
 		if ($this->fieldObjectsRetrieved) {
 			if ($this->fieldObjects) {

--- a/drivers/adodb-firebird.inc.php
+++ b/drivers/adodb-firebird.inc.php
@@ -1053,7 +1053,7 @@ class ADORecordset_firebird extends ADORecordSet
 	 * @param int $fieldOffset (optional default=-1 for all
 	 * @return mixed an ADOFieldObject, or array of objects
 	 */
-	protected function _fetchField($fieldOffset = -1)
+	protected function setFieldObjectsCache($fieldOffset = -1)
 	{
 		if ($this->fieldObjectsRetrieved) {
 			if ($this->fieldObjects) {
@@ -1143,7 +1143,7 @@ class ADORecordset_firebird extends ADORecordSet
 		* Retrieve all of the column information first. We copy
 		* this method from oracle
 		*/
-		$this->_fetchField();
+		$this->setFieldObjectsCache();
 
 	}
 

--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -1125,7 +1125,7 @@ class ADORecordset_mssqlnative extends ADORecordSet {
 	{
 		$this->_numOfRows = -1;//not supported
 		// Cache the metadata right now
-		$this->_fetchField();
+		$this->setFieldObjectsCache();
 
 	}
 
@@ -1176,7 +1176,7 @@ class ADORecordset_mssqlnative extends ADORecordSet {
 	* @param int $fieldOffset (optional default=-1 for all
 	* @return mixed an ADOFieldObject, or array of objects
 	*/
-	private function _fetchField($fieldOffset = -1)
+	protected function setFieldObjectsCache($fieldOffset = -1)
 	{
 		if ($this->fieldObjectsRetrieved) {
 			if ($this->fieldObjectsCache) {

--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -1578,7 +1578,7 @@ class ADORecordset_oci8 extends ADORecordSet {
 
 	var $databaseType = 'oci8';
 	var $bind=false;
-	var $_fieldobjs;
+	
 
 	function __construct($queryID,$mode=false)
 	{
@@ -1648,14 +1648,19 @@ class ADORecordset_oci8 extends ADORecordSet {
 		}
 	}
 
+	/**
+	 * Initializes Recordset and metadata
+	 *
+	 * @return void
+	 */
 	function _initrs()
 	{
 		$this->_numOfRows = -1;
 		$this->_numOfFields = oci_num_fields($this->_queryID);
-		if ($this->_numOfFields>0) {
-			$this->_fieldobjs = array();
-			$max = $this->_numOfFields;
-			for ($i=0;$i<$max; $i++) $this->_fieldobjs[] = $this->_FetchField($i);
+		
+		if ($this->_numOfFields>0) 
+		{
+			$this->setFieldObjectsCache();
 		}
 	}
 
@@ -1665,42 +1670,75 @@ class ADORecordset_oci8 extends ADORecordSet {
 	 * in a certain query result. If the field offset isn't specified, the next
 	 * field that wasn't yet retrieved by fetchField() is retrieved
 	 *
-	 * @return object containing field information
+	 * @param int		$fieldOffset
+	 * @return object 	containing field information
 	 */
-	function _FetchField($fieldOffset = -1)
+	protected function setFieldObjectsCache($fieldOffset = -1)
 	{
-		$fld = new ADOFieldObject;
-		$fieldOffset += 1;
-		$fld->name =oci_field_name($this->_queryID, $fieldOffset);
-		if (ADODB_ASSOC_CASE == ADODB_ASSOC_CASE_LOWER) {
-			$fld->name = strtolower($fld->name);
-		}
-		$fld->type = oci_field_type($this->_queryID, $fieldOffset);
-		$fld->max_length = oci_field_size($this->_queryID, $fieldOffset);
-
-		switch($fld->type) {
-			case 'NUMBER':
-				$p = oci_field_precision($this->_queryID, $fieldOffset);
-				$sc = oci_field_scale($this->_queryID, $fieldOffset);
-				if ($p != 0 && $sc == 0) {
-					$fld->type = 'INT';
+		
+		if ($this->fieldObjectsRetrieved) {
+			if ($this->fieldObjectsCache) {
+				// Already got the information
+				if ($fieldOffset == -1) {
+					return $this->fieldObjectsCache;
+				} else {
+					return $this->fieldObjectsCache[$fieldOffset];
 				}
-				$fld->scale = $p;
-				break;
-
-			case 'CLOB':
-			case 'NCLOB':
-			case 'BLOB':
-				$fld->max_length = -1;
-				break;
+			} else {
+				// No metadata available
+				return false;
+			}
 		}
-		return $fld;
+
+
+		$this->fieldObjectsCache = array();
+		$max = $this->_numOfFields;
+		for ($i=0;$i<$max; $i++)
+		{
+				
+			$fld = new ADOFieldObject;
+
+			$fieldOffset += 1;
+			$fld->name =oci_field_name($this->_queryID, $fieldOffset);
+			if (ADODB_ASSOC_CASE == ADODB_ASSOC_CASE_LOWER) {
+				$fld->name = strtolower($fld->name);
+			}
+			$fld->type = oci_field_type($this->_queryID, $fieldOffset);
+			$fld->max_length = oci_field_size($this->_queryID, $fieldOffset);
+
+			switch($fld->type) {
+				case 'NUMBER':
+					$p = oci_field_precision($this->_queryID, $fieldOffset);
+					$sc = oci_field_scale($this->_queryID, $fieldOffset);
+					if ($p != 0 && $sc == 0) {
+						$fld->type = 'INT';
+					}
+					$fld->scale = $p;
+					break;
+
+				case 'CLOB':
+				case 'NCLOB':
+				case 'BLOB':
+					$fld->max_length = -1;
+					break;
+			}
+			$this->fieldObjectsCache[] = $fld;
+		}
+		$this->fieldObjectsRetrieved = true;
 	}
 
-	/* For some reason, oci_field_name fails when called after _initrs() so we cache it */
-	function FetchField($fieldOffset = -1)
+	/**
+	 * Returns the metadata for a specific field
+	 * for some reason, oci_field_name fails when called after _initrs() so we cache it 
+	 * 
+	 * @param integer $fieldOffset
+	 * 
+	 * @return bool|ADOFieldObject
+	 */
+	function fetchField($fieldOffset = -1)
 	{
-		return $this->_fieldobjs[$fieldOffset];
+		if (array_key_exists($fieldOffset,$this->fieldObjectsCache))
+			return $this->fieldObjectsCache[$fieldOffset];
 	}
 
 

--- a/drivers/adodb-oci8quercus.inc.php
+++ b/drivers/adodb-oci8quercus.inc.php
@@ -38,43 +38,75 @@ class ADORecordset_oci8quercus extends ADORecordset_oci8 {
 
 	var $databaseType = 'oci8quercus';
 
-	function _FetchField($fieldOffset = -1)
+	/**
+	 * Get column information in the Recordset object.
+	 * fetchField() can be used in order to obtain information about fields
+	 * in a certain query result. If the field offset isn't specified, the next
+	 * field that wasn't yet retrieved by fetchField() is retrieved
+	 *
+	 * @param int		$fieldOffset
+	 * @return object 	containing field information
+	 */
+	protected function setFieldObjectsCache($fieldOffset = -1)
 	{
-	global $QUERCUS;
-		$fld = new ADOFieldObject;
+		global $QUERCUS;
 
-		if (!empty($QUERCUS)) {
-			$fld->name = oci_field_name($this->_queryID, $fieldOffset);
-			$fld->type = oci_field_type($this->_queryID, $fieldOffset);
-			$fld->max_length = oci_field_size($this->_queryID, $fieldOffset);
-
-			//if ($fld->name == 'VAL6_NUM_12_4') $fld->type = 'NUMBER';
-			switch($fld->type) {
-				case 'string': $fld->type = 'VARCHAR'; break;
-				case 'real': $fld->type = 'NUMBER'; break;
+		if ($this->fieldObjectsRetrieved) {
+			if ($this->fieldObjectsCache) {
+				// Already got the information
+				if ($fieldOffset == -1) {
+					return $this->fieldObjectsCache;
+				} else {
+					return $this->fieldObjectsCache[$fieldOffset];
+				}
+			} else {
+				// No metadata available
+				return false;
 			}
-		} else {
-			$fieldOffset += 1;
-			$fld->name = oci_field_name($this->_queryID, $fieldOffset);
-			$fld->type = oci_field_type($this->_queryID, $fieldOffset);
-			$fld->max_length = oci_field_size($this->_queryID, $fieldOffset);
-		}
-	 	switch($fld->type) {
-		case 'NUMBER':
-	 		$p = oci_field_precision($this->_queryID, $fieldOffset);
-			$sc = oci_field_scale($this->_queryID, $fieldOffset);
-			if ($p != 0 && $sc == 0) $fld->type = 'INT';
-			$fld->scale = $p;
-			break;
-
-	 	case 'CLOB':
-		case 'NCLOB':
-		case 'BLOB':
-			$fld->max_length = -1;
-			break;
 		}
 
-		return $fld;
+
+		$this->fieldObjectsCache = array();
+		$max = $this->_numOfFields;
+		for ($i=0;$i<$max; $i++)
+		{
+
+			$fld = new ADOFieldObject;
+
+			if (!empty($QUERCUS)) {
+				$fld->name = oci_field_name($this->_queryID, $fieldOffset);
+				$fld->type = oci_field_type($this->_queryID, $fieldOffset);
+				$fld->max_length = oci_field_size($this->_queryID, $fieldOffset);
+
+				//if ($fld->name == 'VAL6_NUM_12_4') $fld->type = 'NUMBER';
+				switch($fld->type) {
+					case 'string': $fld->type = 'VARCHAR'; break;
+					case 'real': $fld->type = 'NUMBER'; break;
+				}
+			} else {
+				$fieldOffset += 1;
+				$fld->name = oci_field_name($this->_queryID, $fieldOffset);
+				$fld->type = oci_field_type($this->_queryID, $fieldOffset);
+				$fld->max_length = oci_field_size($this->_queryID, $fieldOffset);
+			}
+			switch($fld->type) {
+			case 'NUMBER':
+				$p = oci_field_precision($this->_queryID, $fieldOffset);
+				$sc = oci_field_scale($this->_queryID, $fieldOffset);
+				if ($p != 0 && $sc == 0) $fld->type = 'INT';
+				$fld->scale = $p;
+				break;
+
+			case 'CLOB':
+			case 'NCLOB':
+			case 'BLOB':
+				$fld->max_length = -1;
+				break;
+			}
+
+			$this->fieldObjectsCache[] = $fld;
+		}
+		$this->fieldObjectsRetrieved = true;
 	}
 
 }

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -917,6 +917,10 @@ class ADODB_postgres64 extends ADOConnection{
 --------------------------------------------------------------------------------------*/
 
 class ADORecordSet_postgres64 extends ADORecordSet{
+	
+	/*
+	* Holds what fields as blob
+	*/
 	var $_blobArr;
 	var $databaseType = "postgres64";
 	var $canSeek = true;
@@ -951,21 +955,78 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 		return $row;
 	}
 
-	function _initRS()
+	/**
+	 * Initializes Recordset and metadata
+	 *
+	 * @return void
+	 */
+	function _initrs()
 	{
 		global $ADODB_COUNTRECS;
 		$qid = $this->_queryID;
 		$this->_numOfRows = ($ADODB_COUNTRECS)? @pg_num_rows($qid):-1;
 		$this->_numOfFields = @pg_num_fields($qid);
 
-		// cache types for blob decode check
-		// apparently pg_field_type actually performs an sql query on the database to get the type.
-		if (empty($this->connection->noBlobs))
-		for ($i=0, $max = $this->_numOfFields; $i < $max; $i++) {
-			if (pg_field_type($qid,$i) == 'bytea') {
-				$this->_blobArr[$i] = pg_field_name($qid,$i);
+		$this->setFieldObjectsCache();
+
+	}
+
+	/**
+	 * Get column information in the Recordset object.
+	 * fetchField() can be used in order to obtain information about fields
+	 * in a certain query result. If the field offset isn't specified, the next
+	 * field that wasn't yet retrieved by fetchField() is retrieved
+	 *
+	 * @param int		$fieldOffset
+	 * @return object 	containing field information
+	 */
+	protected function setFieldObjectsCache($fieldOffset = -1)
+	{
+		
+		if ($this->fieldObjectsRetrieved) {
+			if ($this->fieldObjectsCache) {
+				// Already got the information
+				if ($fieldOffset == -1) {
+					return $this->fieldObjectsCache;
+				} else {
+					return $this->fieldObjectsCache[$fieldOffset];
+				}
+			} else {
+				// No metadata available
+				return false;
 			}
 		}
+
+
+		$this->fieldObjectsCache = array();
+		$max = $this->_numOfFields;
+		for ($i=0;$i<$max; $i++)
+		{
+				
+			$o = new ADOFieldObject();
+			$o->name = @pg_field_name($this->_queryID, $fieldOffset);
+			$o->type = @pg_field_type($this->_queryID, $fieldOffset);
+			$o->max_length = @pg_field_size($this->_queryID, $fieldOffset);
+			
+			$this->fieldObjectsCache[] = $o;
+
+			
+			/*
+			* cache types for blob decode check
+			* apparently pg_field_type actually performs an sql query on the database to get the type.
+			*/
+			if (empty($this->connection->noBlobs))
+			{
+				if (pg_field_type($qid,$i) == 'bytea') 
+				{
+					$this->_blobArr[$i] = pg_field_name($qid,$i);
+				}
+			}
+
+
+		}
+		$this->fieldObjectsRetrieved = true;
+
 	}
 
 	function fields($colname)
@@ -984,6 +1045,19 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 		return $this->fields[$this->bind[strtoupper($colname)]];
 	}
 
+	/**
+	 * Returns the metadata for a specific field
+	 * 
+	 * @param integer $fieldOffset
+	 * 
+	 * @return bool|ADOFieldObject
+	 */
+	function fetchField($fieldOffset = -1)
+	{
+		if (array_key_exists($fieldOffset,$this->fieldObjectsCache))
+			return $this->fieldObjectsCache[$fieldOffset];
+	}
+	/*
 	function fetchField($fieldOffset = 0)
 	{
 		// offsets begin at 0
@@ -994,6 +1068,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 		$o->max_length = @pg_field_size($this->_queryID, $fieldOffset);
 		return $o;
 	}
+	*/
 
 	function _seek($row)
 	{


### PR DESCRIPTION
The method of retrieval of the field properties of a recordset now has a standardized method, ``adoRecordset::setFieldObjectsCache()``, which is called immediately after initial recordset retrieval via ``init()``. The objects retrieved are stored in a parent level variable, ``adoRecordset::fieldObjectsCache``.  Calls to ``adoRecordSet::fetchfield()`` now simply read this cache instead of re-querying the database. 

 - The cache persists for the life of the recordset
 - This methodology is usable for all drivers
 - Initially covers the following drivers: db2, oci8, mssqlnative, pgsql, firebird 