### PR TITLE
Fix php syntax errors found with phpstan

### DIFF
--- a/adodb-active-record.inc.php
+++ b/adodb-active-record.inc.php
@@ -281,7 +281,7 @@ class ADODB_Active_Record {
 
 	static function TableBelongsTo($table, $foreignRef, $foreignKey=false, $parentKey='', $parentClass = 'ADODB_Active_Record')
 	{
-		$ar = new ADOdb_Active_Record($table);
+		$ar = new ADODB_Active_Record($table);
 		$ar->belongsTo($foreignRef, $foreignKey, $parentKey, $parentClass);
 	}
 
@@ -290,7 +290,7 @@ class ADODB_Active_Record {
 		if (!is_array($tablePKey)) {
 			$tablePKey = array($tablePKey);
 		}
-		$ar = new ADOdb_Active_Record($table, $tablePKey);
+		$ar = new ADODB_Active_Record($table, $tablePKey);
 		$ar->belongsTo($foreignRef, $foreignKey, $parentKey, $parentClass);
 	}
 

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1336,7 +1336,7 @@ if (!defined('_ADODB_LAYER')) {
 			$this->_transOK = false;
 			$this->RollbackTrans();
 			if ($this->debug) {
-				ADOCOnnection::outp("Smart Rollback occurred");
+				ADOConnection::outp("Smart Rollback occurred");
 			}
 		}
 


### PR DESCRIPTION
Working on an open source project that uses ADOdb.
Found these errors when analysing with phpstan in
preparation for PHP8 upgrade.