### PR TITLE
ISSUE - Uninitialized_string_offset_error

### DIFF
--- a/adodb-xmlschema03.inc.php
+++ b/adodb-xmlschema03.inc.php
@@ -600,6 +600,9 @@ class dbTable extends dbObject {
 					if( is_array( $opt ) ) {
 						$key = key( $opt );
 						$value = $opt[key( $opt )];
+						if(!isset($fldarray[$field_id][$key])) {
+							$fldarray[$field_id][$key] = "";
+						}
 						@$fldarray[$field_id][$key] .= $value;
 					// Option doesn't have arguments
 					} else {


### PR DESCRIPTION
```bash
Warning Error: Undefined array key "CONSTRAINT" in [/media/psf/src/comanage/git/registry/app/Vendor/adodb5/adodb-xmlschema03.inc.php, line 603]
```

Since PHP 7.1 uninitialized key offset returned a warning but for later version the code breaks.