### PR TITLE
Add PostgreSQL standard datatypes for UUID, NUMERIC, DECIMAL, FLOAT4 …

### DIFF
--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -1095,6 +1095,7 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 				case 'CIDR':
 				case 'INET':
 				case 'MACADDR':
+				case 'UUID':
 					if ($len <= $this->blobSize) return 'C';
 
 				case 'TEXT':
@@ -1134,6 +1135,12 @@ class ADORecordSet_postgres64 extends ADORecordSet{
 				case 'OID':
 				case 'SERIAL':
 					return 'R';
+
+				case 'NUMERIC':
+				case 'DECIMAL':
+				case 'FLOAT4':
+				case 'FLOAT8':
+					return 'N';
 
 				default:
 					return ADODB_DEFAULT_METATYPE;


### PR DESCRIPTION
Add a few more standard PostgreSQL datatypes for UUID, NUMERIC, DECIMAL, FLOA4 and FLOAT8.

I know ADODB supports custom types now, however since these are standard and have been in PostgreSQL for decades, they should probably be standard in ADODB too.