### PR TITLE
Prevent PHP warning if P1 or P2 happen to be an array.

### DIFF
--- a/adodb-exceptions.inc.php
+++ b/adodb-exceptions.inc.php
@@ -45,6 +45,9 @@ var $database = '';
 			$s = "$dbms error: [$errno: $errmsg] in $fn($p1, '$user', '****', $p2)";
 			break;
 		default:
+			//Prevent PHP warning if $p1 or $p2 are arrays.
+			$p1 = ( is_array($p1) ) ? 'Array' : $p1;
+			$p2 = ( is_array($p2) ) ? 'Array' : $p2;
 			$s = "$dbms error: [$errno: $errmsg] in $fn($p1, $p2)";
 			break;
 		}


### PR DESCRIPTION
When an SQL error triggered and ADODB attempts to output a error message, if the parameters happen to be arrays this will prevent a PHP WARNING from occurring. 