### PR TITLE
Add support for calling a function upon load balancer connection.

### DIFF
--- a/adodb-loadbalancer.inc.php
+++ b/adodb-loadbalancer.inc.php
@@ -233,7 +233,7 @@ class ADOdbLoadBalancer
      * @return bool|ADOConnection
      * @throws Exception
      */
-    public function _getConnection($connection_id)
+    public function getConnectionById( $connection_id)
     {
         if (isset($this->connections[$connection_id])) {
             $connection_obj = $this->connections[$connection_id];
@@ -305,7 +305,7 @@ class ADOdbLoadBalancer
 
             if ($connection_id !== false) {
                 try {
-                    $adodb_obj = $this->_getConnection($connection_id);
+                    $adodb_obj = $this->getConnectionById($connection_id);
 					if ( is_object( $adodb_obj ) ) {
 						break; //Found valid connection, continue with it.
 					} else {
@@ -325,7 +325,7 @@ class ADOdbLoadBalancer
             }
         }
 
-		if ( !isset( $connection_id) ) {
+		if ( !isset($connection_id) ) {
 			throw new Exception('No connection available to use at this time! Type: '. $type );
 		}
 
@@ -446,7 +446,7 @@ class ADOdbLoadBalancer
                         && $connection_obj->getADOdbObject()->_connectionID !== false
                     )
                 ) {
-                    $adodb_obj = $this->_getConnection($key);
+                    $adodb_obj = $this->getConnectionById( $key);
                     if (is_object($adodb_obj)) {
                         $result_arr[] = $adodb_obj->Execute($sql, $inputarr);
                     }

--- a/adodb-loadbalancer.inc.php
+++ b/adodb-loadbalancer.inc.php
@@ -174,7 +174,7 @@ class ADOdbLoadBalancer
      * @param  string $type Type of database connection, either: 'write' capable or 'readonly'
      * @return bool|int|string
      */
-    private function getConnectionByWeight($type)
+    public function getConnectionByWeight($type)
     {
         if ($type == 'readonly') {
             $total_weight = $this->total_connection_weights['all'];
@@ -233,7 +233,7 @@ class ADOdbLoadBalancer
      * @return bool|ADOConnection
      * @throws Exception
      */
-    private function _getConnection($connection_id)
+    public function _getConnection($connection_id)
     {
         if (isset($this->connections[$connection_id])) {
             $connection_obj = $this->connections[$connection_id];
@@ -324,6 +324,10 @@ class ADOdbLoadBalancer
                 throw new Exception('Connection ID is invalid!');
             }
         }
+
+		if ( !isset( $connection_id) ) {
+			throw new Exception('No connection available to use at this time! Type: '. $type );
+		}
 
         $this->last_connection_id[$type] = $connection_id;
 
@@ -605,6 +609,7 @@ class ADOdbLoadBalancer
             case 'binddate':
             case 'bindtimestamp':
             case 'setfetchmode':
+			case 'setcustommetatype':
                   $type = false; // No connection necessary.
                 break;
 


### PR DESCRIPTION
Add support for specifying a callback function that can be run to test load balanced database connections on the first connection. This is useful for things like testing replication delay to make sure its within threshold limits. If the connection test fails, then the connection will be discarded and a different connection will be attempted instead.

Example usage:
```
					$db_connection_obj = new ADOdbLoadBalancerConnection( ... );
					$db_connection_obj->setConnectionTestCallback( function( $connection_obj, $adodb_obj ) use () {
						if ( $connection_obj->type == 'readonly' ) {
							//When connecting to a readonly database, make sure the replication delay never exceeds our threshold, otherwise discard the connection and try a different host.
							$maximum_replication_delay = 60; //Seconds							

							$result = (float)$adodb_obj->GetOne( 'SELECT EXTRACT(epoch FROM ( now() - CASE WHEN pg_last_xact_replay_timestamp() IS NULL THEN now() ELSE pg_last_xact_replay_timestamp() END ) ) AS replication_delay' );
							if ( $result <= $maximum_replication_delay ) {
								return true;
							} else {
								return false;
							}
						}

						return true; //Always return true for master connections.
					} );
```