### PR TITLE
Fix PHP FATAL: Uncaught ArgumentCountError: Too few arguments

### DIFF
--- a/adodb-csvlib.inc.php
+++ b/adodb-csvlib.inc.php
@@ -74,7 +74,7 @@ $ADODB_INCLUDED_CSV = 1;
 
 		$savefetch = isset($rs->adodbFetchMode) ? $rs->adodbFetchMode : $rs->fetchMode;
 		$class = $rs->connection->arrayClass;
-		$rs2 = new $class();
+		$rs2 = new $class( -1 );
 		$rs2->timeCreated = $rs->timeCreated; # memcache fix
 		$rs2->sql = $rs->sql;
 		$rs2->oldProvider = $rs->dataProvider;


### PR DESCRIPTION
When calling _rs2serialize() in adodb-csvlib.inc.php directly, it tries to instantiate a new 'ADORecordSet_array' object, which now requires the first parameter to be specified as of commit: 57186f905c9a1e49a010daf582baa9a07be826bb -- Prior to that it just defaulted to "1". 

Not sure why the default was removed, but we could put it back instead, or make this proposed change. Not sure if "1" or "-1" makes any real difference, but I seem to recall seeing "-1" used in other places.
