### PR TITLE
Add ADOConnection::releaseStatement() method

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1050,6 +1050,17 @@ if (!defined('_ADODB_LAYER')) {
 	}
 
 	/**
+	 * Releases a previously prepared statement.
+	 *
+	 * @param mixed $stmt Statement resource, as returned by {@see prepare()}
+	 *
+	 * @return bool
+	 */
+	function releaseStatement($stmt) {
+		return true;
+	}
+
+	/**
 	 * Prepare a Stored Procedure and return the statement resource.
 	 *
 	 * Some databases, eg. mssql require a different function for preparing

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1056,7 +1056,7 @@ if (!defined('_ADODB_LAYER')) {
 	 *
 	 * @return bool
 	 */
-	function releaseStatement($stmt) {
+	function releaseStatement(&$stmt) {
 		return true;
 	}
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,8 @@ Older changelogs:
   [#676](https://github.com/ADOdb/ADOdb/issues/676)
 - mssql: implement offsetDate() method
   [#698](https://github.com/ADOdb/ADOdb/issues/698)
+- oci8: new ADOConnection::releaseStatement() method
+  [#770](https://github.com/ADOdb/ADOdb/issues/770)
 - sqlite3 performance monitor stub
   [#661](https://github.com/ADOdb/ADOdb/issues/661)
 - sqlite: support blob handling

--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -1094,10 +1094,16 @@ END;
 		return array($sql,$stmt,0,$BINDNUM);
 	}
 
-	function releaseStatement($stmt)
+	function releaseStatement(&$stmt)
 	{
-		if (is_array($stmt) && is_resource($stmt[1])) {
-			return oci_free_statement($stmt[1]);
+		if (is_array($stmt)
+			&& isset($stmt[1])
+			&& is_resource($stmt[1])
+			&& oci_free_statement($stmt[1])
+		) {
+			// Clearing the resource to avoid it being of type Unknown
+			$stmt[1] = null;
+			return true;
 		}
 
 		// Not a valid prepared statement

--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -1094,6 +1094,16 @@ END;
 		return array($sql,$stmt,0,$BINDNUM);
 	}
 
+	function releaseStatement($stmt)
+	{
+		if (is_array($stmt) && is_resource($stmt[1])) {
+			return oci_free_statement($stmt[1]);
+		}
+
+		// Not a valid prepared statement
+		return false;
+	}
+
 	/*
 		Call an oracle stored procedure and returns a cursor variable as a recordset.
 		Concept by Robert Tuttle robert@ud.com


### PR DESCRIPTION
This allows Oracle users to avoid reaching the maximum open cursors
limit, to release the statement resource allocated by oci_parse() and
prevent an ORA-01000 error.

Fixes #770