### PR TITLE
[mysqli] Remove mysqli driver  legacy option flags parameter, see #814

### DIFF
--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -66,7 +66,7 @@ class ADODB_mysqli extends ADOConnection {
 	var $socket = ''; //Default to empty string to fix HHVM bug
 	var $_bindInputArray = false;
 	var $nameQuote = '`';		/// string to use to quote identifiers and names
-	var $optionFlags = array(array(MYSQLI_READ_DEFAULT_GROUP,0));
+
 	var $arrayClass = 'ADORecordSet_array_mysqli';
 	var $multiQuery = false;
 	var $ssl_key = null;
@@ -176,15 +176,7 @@ class ADODB_mysqli extends ADOConnection {
 			}
 			return false;
 		}
-		/*
-		I suggest a simple fix which would enable adodb and mysqli driver to
-		read connection options from the standard mysql configuration file
-		/etc/my.cnf - "Bastien Duclaux" <bduclaux#yahoo.com>
-		*/
-		$this->optionFlags = array();
-		foreach($this->optionFlags as $arr) {
-			mysqli_options($this->_connectionID,$arr[0],$arr[1]);
-		}
+		
 
 		// Now merge in the standard connection parameters setting
 		foreach ($this->connectionParameters as $options) {


### PR DESCRIPTION
Obsolete feature replaced by use of standard setConnectionParameter() methodology