### PR TITLE
Set the Oracle client identifier via setConnectionParameter, see #805

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,8 @@ Older changelogs:
 
 - oci8: support session_mode parameter
   [#801](https://github.com/ADOdb/ADOdb/issues/801)
+- oci8: support setting the client identifier 
+  [#805](https://github.com/ADOdb/ADOdb/issues/805)
 
 ### Removed
 - mysqli: legacy non-functional $optionFlags property

--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -270,11 +270,17 @@ END;
 		}
 
 		// Process the connection parameters
-		$sessionMode = OCI_DEFAULT;
+		$sessionMode      = OCI_DEFAULT;
+		$clientIdentifier = '';
 		foreach ($this->connectionParameters as $options) {
 			foreach($options as $parameter => $value) {
-				if ($parameter == 'session_mode') {
-					$sessionMode = $value;
+				switch ($parameter) {
+					case 'session_mode':
+						$sessionMode = $value;
+						break;
+					case 'client_identifier':
+						$clientIdentifier = $value;
+						break;
 				}
 			}
 		}
@@ -288,6 +294,11 @@ END;
 		);
 		if (!$this->_connectionID) {
 			return false;
+		}
+
+		// Set client identifier, but see documentation for limitations
+		if ($clientIdentifier) {
+			oci_set_client_identifier($this->_connectionID, $clientIdentifier);
 		}
 
 		if ($mode == 1 && $this->autoRollback ) {


### PR DESCRIPTION
The oracle client identifier can now be set via the ``setConnectionParameter()`` method