### PR TITLE
sqlserver: insert_id returns false if value is out of range of INT, see #853

### DIFF
--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -661,7 +661,7 @@ class ADODB_mssqlnative extends ADOConnection {
 			// e.g. if triggers are involved (see #41)
 			while (sqlsrv_next_result($rez)) {
 				sqlsrv_fetch($rez);
-				$this->lastInsID = sqlsrv_get_field($rez, 0, SQLSRV_PHPTYPE_INT);
+				$this->lastInsID = sqlsrv_get_field($rez, 0);
 			}
 		}
 		return $rez;


### PR DESCRIPTION
Insert_id attempts to force the return to an integer data type which fails if the value is out of range