### PR TITLE
PHP 8.1 - replace strftime() with date() - sqlite 

### DIFF
--- a/drivers/adodb-sqlite.inc.php
+++ b/drivers/adodb-sqlite.inc.php
@@ -388,7 +388,7 @@ class ADODB_sqlite extends ADOConnection {
 	 */
 	function month($fld)
 	{
-		$x = "strftime('%m',$fld)";
+		$x = "date('m',$fld)";
 
 		return $x;
 	}
@@ -400,7 +400,7 @@ class ADODB_sqlite extends ADOConnection {
 	 * @return	str				The SQL Statement
 	 */
 	function day($fld) {
-		$x = "strftime('%d',$fld)";
+		$x = "date('d',$fld)";
 		return $x;
 	}
 
@@ -411,7 +411,7 @@ class ADODB_sqlite extends ADOConnection {
 	 * @return	str				The SQL Statement
 	 */
 	function year($fld) {
-		$x = "strftime('%Y',$fld)";
+		$x = "date('Y',$fld)";
 
 		return $x;
 	}

--- a/drivers/adodb-sqlite3.inc.php
+++ b/drivers/adodb-sqlite3.inc.php
@@ -564,34 +564,28 @@ class ADODB_sqlite3 extends ADOConnection {
 	/**
 	 * Converts a date to a month only field and pads it to 2 characters
 	 *
-	 * This uses the more efficient strftime native function to process
-	 *
 	 * @param string $fld	The name of the field to process
 	 *
 	 * @return string The SQL Statement
 	 */
 	function month($fld)
 	{
-		return "strftime('%m',$fld)";
+		return "date('m',$fld)";
 	}
 
 	/**
 	 * Converts a date to a day only field and pads it to 2 characters
-	 *
-	 * This uses the more efficient strftime native function to process
 	 *
 	 * @param string $fld	The name of the field to process
 	 *
 	 * @return string The SQL Statement
 	 */
 	function day($fld) {
-		return "strftime('%d',$fld)";
+		return "date('d',$fld)";
 	}
 
 	/**
 	 * Converts a date to a year only field
-	 *
-	 * This uses the more efficient strftime native function to process
 	 *
 	 * @param string $fld	The name of the field to process
 	 *
@@ -599,7 +593,7 @@ class ADODB_sqlite3 extends ADOConnection {
 	 */
 	function year($fld)
 	{
-		return "strftime('%Y',$fld)";
+		return "date('%Y',$fld)";
 	}
 
 	/**


### PR DESCRIPTION
Because strftime() has been deprecated in PHP 8.1 and these functions will be removed in PHP 9.0, I've replaced it with date().

In adodb-time.inc.php  gmstrftime() is used but I was no able to find the way to fix it.
