### PR TITLE
[core] Fix error in _adodb_backtrace() when the number of repeats in str_repeat reaches zero

### DIFF
--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -1227,7 +1227,7 @@ function _adodb_column_sql(&$zthis, $action, $type, $fname, $fnameq, $arrFields,
 		*/
 		if ($zthis->debug !== -99)
 		{
-			$outString = sprintf("%s\n%s\n    %s \n%s\n",str_repeat('-',78),$myDatabaseType,$sqlTxt,$ss,str_repeat('-',78));
+			$outString = sprintf("%s\n%s\n    %s %s \n%s\n",str_repeat('-',78),$myDatabaseType,$sqlTxt,$ss,str_repeat('-',78));
 			ADOConnection::outp($outString,false);
 		}
 	}
@@ -1268,8 +1268,8 @@ function _adodb_column_sql(&$zthis, $action, $type, $fname, $fnameq, $arrFields,
 				ADOConnection::outp(sprintf($outString, $myDatabaseType,htmlspecialchars($sqlTxt),$ss),false);
 			}
 			else
-			{				
-				$outString = sprintf("%s\n%s\n    %s\n%s\n",str_repeat('-',78),$myDatabaseType,$sqlTxt,$ss,str_repeat('-',78));
+			{
+				$outString = sprintf("%s\n%s\n    %s %s \n%s\n",str_repeat('-',78),$myDatabaseType,$sqlTxt,$ss,str_repeat('-',78));
 				ADOConnection::outp($outString,false);
 			}
 		}

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -1152,10 +1152,21 @@ function _adodb_column_sql(&$zthis, $action, $type, $fname, $fnameq, $arrFields,
 }
 
 
-
-function _adodb_debug_execute($zthis, $sql, $inputarr)
+/**
+* Replaces standard _execute when debug is enabled
+*
+* @param	obj				$zthis	An ADOConnection object
+* @param	string			$sql	A string or array of SQL statements
+* @param	string[]|null	$inputarr	An optional array of bind parameters
+*
+* @return  handle|void		A handle to the executed query
+*/
+ function _adodb_debug_execute($zthis, $sql, $inputarr)
 {
 	$ss = '';
+	/*
+	* Unpack the bind parameters
+	*/
 	if ($inputarr) {
 		foreach($inputarr as $kk=>$vv) {
 			if (is_string($vv) && strlen($vv)>64) $vv = substr($vv,0,64).'...';
@@ -1173,6 +1184,16 @@ function _adodb_debug_execute($zthis, $sql, $inputarr)
 		$ss = "[ $ss ]";
 	}
 	$sqlTxt = is_array($sql) ? $sql[0] : $sql;
+	
+	/*
+	* Remove newlines and tabs
+	*/
+	$sqlTxt = str_replace(array("\r","\n","\t"),' ',$sqlTxt);
+	
+	/*
+	* Compress repeating spaces
+	*/
+	$sqlText = preg_replace('/\s+/',' ',$sqlTxt);
 	/*str_replace(', ','##1#__^LF',is_array($sql) ? $sql[0] : $sql);
 	$sqlTxt = str_replace(',',', ',$sqlTxt);
 	$sqlTxt = str_replace('##1#__^LF', ', ' ,$sqlTxt);
@@ -1180,21 +1201,49 @@ function _adodb_debug_execute($zthis, $sql, $inputarr)
 	// check if running from browser or command-line
 	$inBrowser = isset($_SERVER['HTTP_USER_AGENT']);
 
-	$dbt = $zthis->databaseType;
-	if (isset($zthis->dsnType)) $dbt .= '-'.$zthis->dsnType;
-	if ($inBrowser) {
+	$myDatabaseType = $zthis->databaseType;
+	
+	if (isset($zthis->dsnType)) 
+		/*
+		* Append the PDO driver name
+		*/
+		$myDatabaseType .= '-'.$zthis->dsnType;
+		
+	if ($inBrowser) 
+	{
 		if ($ss) {
-			$ss = '<code>'.htmlspecialchars($ss).'</code>';
+			/*
+			* Default formatting for passed parameter 
+			*/
+			$ss = sprintf('<code class="adodb-debug">%s</code>',htmlspecialchars($ss));
 		}
 		if ($zthis->debug === -1)
-			ADOConnection::outp( "<br>\n($dbt): ".htmlspecialchars($sqlTxt)." &nbsp; $ss\n<br>\n",false);
+		{
+			$outString = "<br class='adodb-debug'>(%s):  %s &nbsp; %s<br class='adodb-debug'>";
+			ADOConnection::outp(sprintf($outString,$myDatabaseType,htmlspecialchars($sqlTxt),$ss),false);
+		}
 		else if ($zthis->debug !== -99)
-			ADOConnection::outp( "<hr>\n($dbt): ".htmlspecialchars($sqlTxt)." &nbsp; $ss\n<hr>\n",false);
-	} else {
-		$ss = "\n   ".$ss;
+		{
+			$outString = "<hr class='adodb-debug'>(%s):  %s &nbsp; %s<hr class='adodb-debug'>";
+			ADOConnection::outp(sprintf($outString, $myDatabaseType,htmlspecialchars($sqlTxt),$ss),false);
+		}
+	} 
+	else 
+	{
+		/*
+		* CLI output
+		*/
 		if ($zthis->debug !== -99)
-			ADOConnection::outp("-----<hr>\n($dbt): ".$sqlTxt." $ss\n-----<hr>\n",false);
+		{
+			$outString = sprintf("%s\n%s\n    %s \n%s\n",str_repeat('-',78),$myDatabaseType,$sqlTxt,$ss,str_repeat('-',78));
+			ADOConnection::outp($outString,false);
+		}
 	}
+
+	
+	/*
+	* Now execute the query
+	*/
 
 	$qID = $zthis->_query($sql,$inputarr);
 
@@ -1208,64 +1257,156 @@ function _adodb_debug_execute($zthis, $sql, $inputarr)
 		if($emsg = $zthis->ErrorMsg()) {
 			if ($err = $zthis->ErrorNo()) {
 				if ($zthis->debug === -99)
-					ADOConnection::outp( "<hr>\n($dbt): ".htmlspecialchars($sqlTxt)." &nbsp; $ss\n<hr>\n",false);
+					
+					ADOConnection::outp( "<hr>\n($myDatabaseType): ".htmlspecialchars($sqlTxt)." &nbsp; $ss\n<hr>\n",false);
 
 				ADOConnection::outp($err.': '.$emsg);
 			}
 		}
-	} else if (!$qID) {
-
+	} 
+	else if (!$qID) {
+		/*
+		* Statement execution has failed
+		*/
 		if ($zthis->debug === -99)
-				if ($inBrowser) ADOConnection::outp( "<hr>\n($dbt): ".htmlspecialchars($sqlTxt)." &nbsp; $ss\n<hr>\n",false);
-				else ADOConnection::outp("-----<hr>\n($dbt): ".$sqlTxt."$ss\n-----<hr>\n",false);
-
+		{
+			if ($inBrowser)
+			{
+				$outString = "<hr class='adodb-debug'>(%s):  %s &nbsp; %s<hr class='adodb-debug'>";
+				ADOConnection::outp(sprintf($outString, $myDatabaseType,htmlspecialchars($sqlTxt),$ss),false);
+			}
+			else
+			{				
+				$outString = sprintf("%s\n%s\n    %s\n%s\n",str_repeat('-',78),$myDatabaseType,$sqlTxt,$ss,str_repeat('-',78));
+				ADOConnection::outp($outString,false);
+			}
+		}
+		
+		/*
+		* Send last error to output
+		*/
 		ADOConnection::outp($zthis->ErrorNo() .': '. $zthis->ErrorMsg());
 	}
 
-	if ($zthis->debug === 99) _adodb_backtrace(true,9999,2);
+	if ($zthis->debug === 99) 
+	{
+		_adodb_backtrace(true,9999,2);
+	}
 	return $qID;
 }
 
-# pretty print the debug_backtrace function
-function _adodb_backtrace($printOrArr=true,$levels=9999,$skippy=0,$ishtml=null)
+/**
+ * pretty print the debug_backtrace function
+ *
+ * @param string[]|bool $printOrArr			Whether to print the result directly or return the result
+ * @param int			$maximumDepth		The maximum depth of the array to traverse
+ * @param int			$elementsToIgnore	The backtrace array indexes to ignore
+ * @param null|bool  	$ishtml			  	Are we in a CLI or CGI environment
+ *
+ * @return void
+ */
+function _adodb_backtrace($printOrArr=true,$maximumDepth=9999,$elementsToIgnore=0,$ishtml=null)
 {
-	if (!function_exists('debug_backtrace')) return '';
+	if (!function_exists('debug_backtrace')) 
+		return '';
 
-	if ($ishtml === null) $html = (isset($_SERVER['HTTP_USER_AGENT']));
-	else $html = $ishtml;
+	if ($ishtml === null)
+		/*
+		Auto determine if we in a CGI enviroment
+		*/
+		$html = (isset($_SERVER['HTTP_USER_AGENT']));
+	else 
+		$html = $ishtml;
 
-	$fmt = ($html) ? "</font><font color=#808080 size=-1> %% line %4d, file: <a href=\"file:/%s\">%s</a></font>" : "%% line %4d, file: %s";
+	$cgiString = "</font><font color=#808080 size=-1> %% line %4d, file: <a href=\"file:/%s\">%s</a></font>";
+	$cliString =  "%% line %4d, file: %s";
+	$fmt = ($html) ? $cgiString : $cliString;
 
 	$MAXSTRLEN = 128;
 
 	$s = ($html) ? '<pre align=left>' : '';
+	
+	
+	if (is_array($printOrArr)) 
+		$traceArr = $printOrArr;
+	else 
+		$traceArr = debug_backtrace();
+	
 
-	if (is_array($printOrArr)) $traceArr = $printOrArr;
-	else $traceArr = debug_backtrace();
+	/*
+	* Remove first 2 elements that just show calls to  adodb_backtrace
+	*/
 	array_shift($traceArr);
 	array_shift($traceArr);
-	$tabs = sizeof($traceArr)-2;
 
-	foreach ($traceArr as $arr) {
-		if ($skippy) {$skippy -= 1; continue;}
-		$levels -= 1;
-		if ($levels < 0) break;
+	/*
+	* We want last element to have no indent
+	*/
+	$tabs = sizeof($traceArr) - 1;
+	
+	
+	foreach ($traceArr as $arr) 
+	{
+		if ($elementsToIgnore) 
+		{
+			/*
+			* Ignore array element at start of array
+			*/
+			$elementsToIgnore--; 
+			continue;
+		}
+		$maximumDepth--;
+		if ($maximumDepth < 0) 
+			break;
 
 		$args = array();
-		$s .= str_repeat($html ? ' &nbsp; ' : "\t", $tabs);
-		$tabs -= 1;
-		if ($html) $s .= '<font face="Courier New,Courier">';
-		if (isset($arr['class'])) $s .= $arr['class'].'.';
+		
+		if ($tabs)
+		{
+			$s .= str_repeat($html ? ' &nbsp; ' : "\t", $tabs);
+			$tabs --;
+		}
+		if ($html) 
+			$s .= '<font face="Courier New,Courier">';
+		
+		if (isset($arr['class'])) 
+			$s .= $arr['class'].'.';
+		
 		if (isset($arr['args']))
-		 foreach($arr['args'] as $v) {
-			if (is_null($v)) $args[] = 'null';
-			else if (is_array($v)) $args[] = 'Array['.sizeof($v).']';
-			else if (is_object($v)) $args[] = 'Object:'.get_class($v);
-			else if (is_bool($v)) $args[] = $v ? 'true' : 'false';
+		foreach($arr['args'] as $v) 
+		{
+			if (is_null($v)) 
+				$args[] = 'null';
+			else if (is_array($v)) 
+				$args[] = 'Array['.sizeof($v).']';
+			else if (is_object($v)) 
+				$args[] = 'Object:'.get_class($v);
+			else if (is_bool($v)) 
+				$args[] = $v ? 'true' : 'false';
 			else {
 				$v = (string) @$v;
-				$str = htmlspecialchars(str_replace(array("\r","\n"),' ',substr($v,0,$MAXSTRLEN)));
-				if (strlen($v) > $MAXSTRLEN) $str .= '...';
+				/*
+				* Truncate
+				*/
+				$v = substr($v,0,$MAXSTRLEN);
+				/*
+				* Remove newlines and tabs
+				*/
+				$v = str_replace(array("\r","\n","\t"),' ',$v);
+				
+				/*
+				* Compress repeating spaces
+				*/
+				$v = preg_replace('/\s+/',' ',$v);
+				
+				/*
+				* Convert htmlchars (not sure why we do this in CLI)
+				*/
+				$str = htmlspecialchars($v);
+				
+				if (strlen($v) > $MAXSTRLEN) 
+					$str .= '...';
+				
 				$args[] = $str;
 			}
 		}
@@ -1275,8 +1416,10 @@ function _adodb_backtrace($printOrArr=true,$levels=9999,$skippy=0,$ishtml=null)
 
 		$s .= "\n";
 	}
-	if ($html) $s .= '</pre>';
-	if ($printOrArr) print $s;
+	if ($html) 
+		$s .= '</pre>';
+	if ($printOrArr) 
+		print $s;
 
 	return $s;
 }

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -1186,18 +1186,10 @@ function _adodb_column_sql(&$zthis, $action, $type, $fname, $fnameq, $arrFields,
 	$sqlTxt = is_array($sql) ? $sql[0] : $sql;
 	
 	/*
-	* Remove newlines and tabs
+	* Remove newlines and tabs,compress repeating spaces
 	*/
-	$sqlTxt = str_replace(array("\r","\n","\t"),' ',$sqlTxt);
+	$sqlTxt = preg_replace('/\s+/',' ',$sqlTxt);
 	
-	/*
-	* Compress repeating spaces
-	*/
-	$sqlText = preg_replace('/\s+/',' ',$sqlTxt);
-	/*str_replace(', ','##1#__^LF',is_array($sql) ? $sql[0] : $sql);
-	$sqlTxt = str_replace(',',', ',$sqlTxt);
-	$sqlTxt = str_replace('##1#__^LF', ', ' ,$sqlTxt);
-	*/
 	// check if running from browser or command-line
 	$inBrowser = isset($_SERVER['HTTP_USER_AGENT']);
 
@@ -1390,12 +1382,7 @@ function _adodb_backtrace($printOrArr=true,$maximumDepth=9999,$elementsToIgnore=
 				*/
 				$v = substr($v,0,$MAXSTRLEN);
 				/*
-				* Remove newlines and tabs
-				*/
-				$v = str_replace(array("\r","\n","\t"),' ',$v);
-				
-				/*
-				* Compress repeating spaces
+				* Remove newlines and tabs, compress repeating spaces
 				*/
 				$v = preg_replace('/\s+/',' ',$v);
 				

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -1191,7 +1191,7 @@ function _adodb_debug_execute($zthis, $sql, $inputarr)
 	$inBrowser = isset($_SERVER['HTTP_USER_AGENT']);
 
 	$myDatabaseType = $zthis->databaseType;
-	if (isset($zthis->dsnType)) {
+	if (!isset($zthis->dsnType)) {
 		// Append the PDO driver name
 		$myDatabaseType .= '-' . $zthis->dsnType;
 	}

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -1153,13 +1153,13 @@ function _adodb_column_sql(&$zthis, $action, $type, $fname, $fnameq, $arrFields,
 
 
 /**
-* Replaces standard _execute when debug is enabled
+* Replaces standard _execute when debug mode is enabled
 *
-* @param	obj				$zthis	An ADOConnection object
-* @param	string			$sql	A string or array of SQL statements
-* @param	string[]|null	$inputarr	An optional array of bind parameters
+* @param ADOConnection   $zthis    An ADOConnection object
+* @param string|string[] $sql      A string or array of SQL statements
+* @param string[]|null   $inputarr An optional array of bind parameters
 *
-* @return  handle|void		A handle to the executed query
+* @return  handle|void A handle to the executed query
 */
 function _adodb_debug_execute($zthis, $sql, $inputarr)
 {
@@ -1257,14 +1257,15 @@ function _adodb_debug_execute($zthis, $sql, $inputarr)
 }
 
 /**
- * pretty print the debug_backtrace function
+ * Pretty print the debug_backtrace function
  *
- * @param string[]|bool $printOrArr			Whether to print the result directly or return the result
- * @param int			$maximumDepth		The maximum depth of the array to traverse
- * @param int			$elementsToIgnore	The backtrace array indexes to ignore
- * @param null|bool  	$ishtml			  	Are we in a CLI or CGI environment
+ * @param string[]|bool $printOrArr       Whether to print the result directly or return the result
+ * @param int           $maximumDepth     The maximum depth of the array to traverse
+ * @param int           $elementsToIgnore The backtrace array indexes to ignore
+ * @param null|bool     $ishtml           True if we are in a CGI environment, false for CLI,
+ *                                        null to auto detect
  *
- * @return void
+ * @return string Formatted backtrace
  */
 function _adodb_backtrace($printOrArr=true, $maximumDepth=9999, $elementsToIgnore=0, $ishtml=null)
 {

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -1305,6 +1305,7 @@ function _adodb_backtrace($printOrArr=true, $maximumDepth=9999, $elementsToIgnor
 		if ($elementsToIgnore) {
 			// Ignore array element at start of array
 			$elementsToIgnore--;
+			$tabs--;
 			continue;
 		}
 		$maximumDepth--;

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -1246,7 +1246,10 @@ function _adodb_debug_execute($zthis, $sql, $inputarr)
 			}
 
 			// Send last error to output
-			ADOConnection::outp($zthis->ErrorNo() . ': ' . $zthis->ErrorMsg());
+			$errno = $zthis->ErrorNo();
+			if ($errno) {
+				ADOConnection::outp($errno . ': ' . $zthis->ErrorMsg());
+			}
 		}
 	}
 

--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -1250,8 +1250,8 @@ function _adodb_debug_execute($zthis, $sql, $inputarr)
 		}
 	}
 
-	if ($zthis->debug === 99) {
-		_adodb_backtrace(true, 9999, 2);
+	if ($qID === false || $zthis->debug === 99) {
+		_adodb_backtrace();
 	}
 	return $qID;
 }

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1556,9 +1556,6 @@ if (!defined('_ADODB_LAYER')) {
 
 		// error handling if query fails
 		if ($this->_queryID === false) {
-			if ($this->debug == 99) {
-				adodb_backtrace(true,5);
-			}
 			$fn = $this->raiseErrorFn;
 			if ($fn) {
 				$fn($this->databaseType,'EXECUTE',$this->ErrorNo(),$this->ErrorMsg(),$sql,$inputarr,$this);

--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -645,13 +645,6 @@ class ADODB_mssqlnative extends ADOConnection {
 			$rez = sqlsrv_query($this->_connectionID, $sql);
 		}
 
-		if ($this->debug) {
-			ADOConnection::outp("<hr>running query: " . var_export($sql, true)
-				. "<hr>input array: " . var_export($inputarr, true)
-				. "<hr>result: " . var_export($rez, true)
-			);
-		}
-
 		$this->lastInsID = false;
 		if (!$rez) {
 			$rez = false;


### PR DESCRIPTION
1. Fixes the error that occurs when the str_repeat() number of repeats reaches zero
2. Refactors the function to improve variable naming and docblocks
3. Removes an unneeded debug statement in the mssqlnative driver
4. The [Debug documentation](https://adodb.org/dokuwiki/doku.php?id=v5:userguide:debug#special_options) has been updated to document the special parameters, (99,-1,-99) that can be used to change the output