### PR TITLE
Fix uncaught TypeError in Firebird/Interbase drivers

### DIFF
--- a/drivers/adodb-firebird.inc.php
+++ b/drivers/adodb-firebird.inc.php
@@ -517,6 +517,12 @@ class ADODB_firebird extends ADOConnection {
 		}
 		$ret = call_user_func_array($fn, $args);
 
+		// fbird_query() and fbird_execute() return number of affected rows
+		// ADOConnection::_Execute() expects true for INSERT/UPDATE/DELETE
+		if (is_numeric($ret)) {
+			$ret = true;
+		}
+
 		if ($docommit && $ret === true) {
 			fbird_commit($this->_connectionID);
 		}

--- a/drivers/adodb-ibase.inc.php
+++ b/drivers/adodb-ibase.inc.php
@@ -366,6 +366,13 @@ class ADODB_ibase extends ADOConnection {
 				$ret = $fn($conn, $sql);
 			}
 		}
+
+		// ibase_query() and ibase_execute() return number of affected rows
+		// ADOConnection::_Execute() expects true for INSERT/UPDATE/DELETE
+		if (is_numeric($ret)) {
+			$ret = true;
+		}
+
 		if ($docommit && $ret === true) {
 			ibase_commit($this->_connectionID);
 		}


### PR DESCRIPTION
On PHP 8.x, executing an update query with the Firebird or Interbase
driver results in a Fatal error: Uncaught TypeError: ibase_num_fields():
Argument #1 ($query_result) must be of type resource, int given.

Problem is caused by fbird_query() / ibase_query() returning the number
of affected rows instead when executing INSERT, UPDATE and DELETE
statements, but ADOConnection::_Execute() expects true.

This was already triggering a warning in earlier PHP versions, but it
was silenced by the @ operator.

Fixes #858