### PR TITLE
Untangles the control of the casing and quoting of columns

### DIFF
--- a/adodb-active-record.inc.php
+++ b/adodb-active-record.inc.php
@@ -1123,8 +1123,9 @@ class ADODB_Active_Record {
 	/**
 	 * Quotes the table, column and field names.
 	 *
-	 * This honours the internal {@see $_quoteNames} property, which overrides
-	 * the global $ADODB_QUOTE_FIELDNAMES directive.
+	 * This uses the standard _adodb_quote_fieldname() settings, and ignores 
+	 * the internal {@see $_quoteNames} property, and the global 
+	 * $ADODB_QUOTE_FIELDNAMES directive.
 	 *
 	 * @param ADOConnection $db   The database connection
 	 * @param string        $name The table or column name to quote
@@ -1133,16 +1134,21 @@ class ADODB_Active_Record {
 	 */
 	private function nameQuoter($db, $name)
 	{
-		global $ADODB_QUOTE_FIELDNAMES;
-
-		$save = $ADODB_QUOTE_FIELDNAMES;
-		$ADODB_QUOTE_FIELDNAMES = $this->_quoteNames;
-
-		$string = _adodb_quote_fieldname($db, $name);
-
-		$ADODB_QUOTE_FIELDNAMES = $save;
-
-		return $string;
+		if (isset($this->_quoteNames) && $this->_quoteNames && $db->debug)
+		{
+			$msg = "
+Warning: The class variable '_quoteNames' has been deprecated and will be
+removed in the next release. Control field casing and quoting using 
+ADOConnection::setQuoteStyle() and ADOConnection::setElementCase()
+To match your setting, both quoteStyle and elementCase were set to 1
+To control this manually, remove your _quoteNames setting";
+			ADOConnection::outp($msg);
+			$db->setElementCase(1);
+			$db->setQuoteStyle(1);
+			
+		}
+		
+		return _adodb_quote_fieldname($db, $name);
 	}
 
 };

--- a/adodb-datadict.inc.php
+++ b/adodb-datadict.inc.php
@@ -350,6 +350,17 @@ class ADODB_DataDict {
 		return $this->connection->metaType($t,$len,$fieldobj);
 	}
 
+	/**
+	* A legacy wrapper for the field name quoting system. 
+	* Now calls the standard _adodb_quote_fieldname method and
+	* respects the quote style and casing set there. Ignores
+	* The active record settings for this
+	*
+	* @param string $name	The fieldname
+	* @param bool   $allowBrackets (ignored)
+	*
+	* @return string The processed name
+	*/
 	function nameQuote($name = NULL,$allowBrackets=false)
 	{
 		if (!is_string($name)) {
@@ -362,29 +373,28 @@ class ADODB_DataDict {
 			return $name;
 		}
 
-		$quote = $this->connection->nameQuote;
-
-		// if name is of the form `name`, quote it
-		if ( preg_match('/^`(.+)`$/', $name, $matches) ) {
-			return $quote . $matches[1] . $quote;
-		}
-
-		// if name contains special characters, quote it
-		$regex = ($allowBrackets) ? $this->nameRegexBrackets : $this->nameRegex;
-
-		if ( !preg_match('/^[' . $regex . ']+$/', $name) ) {
-			return $quote . $name . $quote;
-		}
-
-		return $name;
+		return _adodb_quote_fieldname($this->connection,$name);
+		
 	}
 
+	/**
+	* A legacy wrapper for the table name quoting system. 
+	* Now calls the standard _adodb_quote_fieldname method and
+	* respects the quote style and casing set there. Ignores
+	* The active record settings for this
+	*
+	* @param string $name	The table name
+	*
+	* @return string The processed name
+	*/
 	function tableName($name)
 	{
-		if ( $this->schema ) {
-			return $this->nameQuote($this->schema) .'.'. $this->nameQuote($name);
-		}
-		return $this->nameQuote($name);
+		
+		if ($this->schema)
+			$name = sprintf('%s.%s', $this->schema,$name);
+		
+		return _adodb_quote_fieldname($this->connection,$name);
+		
 	}
 
 	// Executes the sql array returned by getTableSQL and getIndexSQL

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -507,9 +507,44 @@ if (!defined('_ADODB_LAYER')) {
 	var $true = '1';			/// string that represents TRUE for a database
 	var $false = '0';			/// string that represents FALSE for a database
 	var $replaceQuote = "\\'";	/// string to use to replace quotes
+	
+	// Items to remove after implementation of new field quoting
+	
 	var $nameQuote = '"';		/// string to use to quote identifiers and names
 	var $leftBracket = '[';		/// left square bracked for t-sql styled column names
 	var $rightBracket = ']';	/// right square bracked for t-sql styled column names
+	
+	const QUOTE_NONE     = 0; /// some_field
+	const QUOTE_SINGLE   = 1; /// 'some_field'
+    const QUOTE_BRACKETS = 2; /// [some_field]
+	
+	protected $elementQuotes     = array('',''); /// default empty style for quoting elements
+	protected $fallbackQuotes    = array('',''); /// fallback style for items is mapped quoteStyles[1]
+	
+	// Used if we need to **force** quoting around a field even though quotes are not used
+	protected $defaultQuoteStyle = 1;
+	
+	/*
+	* Creates a sane representation of quoting. 
+	* Array [0] is the unquoted value
+	* Array [1] is the normal quoting method for the database,
+	* So this changes from one DB to another.
+	* Any index higher than that means that the database has multiple
+	* methods of quoting elements
+	*/
+	protected $quoteStyles = array(
+		array('',''),
+		array('"','"')
+		);
+	
+    // Default casing for columns, tables etc is nativee unchanged 	
+	protected $elementCase = 0;
+	
+	const ELEMENTCASE_DEFAULT  =  0;
+	const ELEMENTCASE_LOWER    =  1;
+	const ELEMENTCASE_UPPER    =  2;
+	
+	
 	var $charSet=false;			/// character set to use - only for interbase, postgres and oci8
 	var $metaDatabasesSQL = '';
 	var $metaTablesSQL = '';
@@ -694,7 +729,90 @@ if (!defined('_ADODB_LAYER')) {
 		$this->connectionParameters[] = array($parameter=>$value);
 		return true;
 	}
+	
+	/**
+	* Sets the style that surrounds the column and table names
+	*
+	* @param int	The quote style
+	*
+	* @return bool whether the set succeeded
+	*/
+	public function setQuoteStyle($styleNumber=0){
+		
+		if (!is_integer($styleNumber))
+			return false;
 
+		if (!array_key_exists($styleNumber,$this->quoteStyles))
+		{
+			// Sets any invalid number to the default quoted value
+			$styleNumber = 1;
+		}
+		
+		$this->elementQuotes = $this->quoteStyles[$styleNumber];
+		
+		/// @todo Set this separately
+		if ($styleNumber == 0)
+			// If we reset the quoting, we need to reset the fallback
+			$this->fallbackQuotes = $this->quoteStyles[$this->defaultQuoteStyle];
+		else
+			
+			$this->fallbackQuotes = $this->quoteStyles[$styleNumber];
+		return true;
+		
+	}
+	
+	/**
+	* Returns the elementQuotes and fallbackQuotes
+	*
+	* @return list
+	*/
+	public function getElementQuotes()
+	{
+		return array($this->elementQuotes,$this->fallbackQuotes);
+	}
+	
+	/**
+	* Returns the available quoting styles
+	*
+	* @return string
+	*/
+	public function getQuoteStyles()
+	{
+		return $this->quoteStyles;
+	}
+	
+	/**
+	* Sets the casing of the columns and tables for getUpdateSql
+	*
+	* @param int	The quote style
+	*
+	* @return bool whether the set succeeded
+	*/
+	public function setElementCase($styleNumber=0){
+		
+		if (!is_integer($styleNumber))
+			return false;
+
+		if ($styleNumber < 0 || $styleNumber > 2)
+			return false;
+		
+		$this->elementCase = $styleNumber;
+		
+		return true;
+		
+	}
+	
+	/**
+	* Returns the casing of the columns and tables for getUpdateSql 
+	*
+	* @return int The quote style
+	*/
+	public function getElementCase(){
+	
+		return $this->elementCase;
+
+	}
+	
 	/**
 	 * ADOdb version.
 	 *

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -66,6 +66,11 @@ class ADODB_mysqli extends ADOConnection {
 	var $socket = ''; //Default to empty string to fix HHVM bug
 	var $_bindInputArray = false;
 	var $nameQuote = '`';		/// string to use to quote identifiers and names
+	
+	protected $quoteStyles = array(
+		array('',''),
+		array("`","`");
+	
 	var $arrayClass = 'ADORecordSet_array_mysqli';
 	var $multiQuery = false;
 	var $ssl_key = null;


### PR DESCRIPTION
#### Note that there is only MySQL driver change. If you think this works, I'll do all the others

The casing of table, column and index names are incorrectly linked to the casing of returned associative array keys and the field quoting performed, see #792. This change separates the feature into distinct methods solely for the feature, and deprecates previous methodologies

@dregad , I am quite happy with the way this has turned out. This removes all of the previous methods of controlling the casing and quoting in core, data dictionary and active records, and replaces all of it with just 2 ADOConnection methods:

````php
$db->setQuoteStyle($integer); // 0 = No quoting, 1 = Normal Quotes e.g. backtick for MySQL
$db->setElementCase($integer) // 0 = No change 1 = Lower Case 2 = UpperCase
````
So looking at a CreateTableSQL, we can see the changes
### Quoting = 0, Casing = 0
````php
Array
(
    [0] => CREATE TABLE quote_test (
COL1                     VARCHAR(32) NOT NULL DEFAULT 'abc',
COL2                     INTEGER NOT NULL AUTO_INCREMENT,
COL3                     NUMERIC(12,2),
COL4                     VARCHAR(64),
COL5                     ENUM('cats','dogs','fish'),
col6                     VARCHAR(10),
`col 7`                  VARCHAR(10), // <--------------------------- Auto quoted because of space in name
                 PRIMARY KEY (COL2)
)
)
````
### Quoting = 1, Casing = 1
````php
Array
(
    [0] => CREATE TABLE `quote_test` (
`col1`                   VARCHAR(32) NOT NULL DEFAULT 'abc',
`col2`                   INTEGER NOT NULL AUTO_INCREMENT,
`col3`                   NUMERIC(12,2),
`col4`                   VARCHAR(64),
`col5`                   ENUM('cats','dogs','fish'),
`col6`                   VARCHAR(10),
`col 7`                  VARCHAR(10),
                 PRIMARY KEY (`col2`)
)
)
````
### Quoting = 1 Casing = 2
````php
Array
(
    [0] => CREATE TABLE `QUOTE_TEST` (
`COL1`                   VARCHAR(32) NOT NULL DEFAULT 'abc',
`COL2`                   INTEGER NOT NULL AUTO_INCREMENT,
`COL3`                   NUMERIC(12,2),
`COL4`                   VARCHAR(64),
`COL5`                   ENUM('cats','dogs','fish'),
`COL6`                   VARCHAR(10),
`COL 7`                  VARCHAR(10),
                 PRIMARY KEY (`COL2`)
)
)
````
