### PR TITLE
mysqli: store error msg/code after query execution

### DIFF
--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -1311,6 +1311,10 @@ class ADODB_mysqli extends ADOConnection {
 
 				$ret = mysqli_stmt_execute($stmt);
 
+				// Store error code and message
+				$this->_errorCode = $stmt->errno;
+				$this->_errorMsg = $stmt->error;
+
 				/*
 				* Did we throw an error?
 				*/
@@ -1336,6 +1340,10 @@ class ADODB_mysqli extends ADOConnection {
 			*/
 			$this->usePreparedStatement   = false;
 			$this->useLastInsertStatement = false;
+
+			// Reset error code and message
+			$this->_errorCode = 0;
+			$this->_errorMsg = '';
 		}
 
 		/*
@@ -1377,10 +1385,12 @@ class ADODB_mysqli extends ADOConnection {
 	 */
 	function ErrorMsg()
 	{
-		if (empty($this->_connectionID)) {
-			$this->_errorMsg = mysqli_connect_error();
-		} else {
-			$this->_errorMsg = $this->_connectionID->error ?? $this->_connectionID->connect_error;
+		if (!$this->_errorMsg) {
+			if (empty($this->_connectionID)) {
+				$this->_errorMsg = mysqli_connect_error();
+			} else {
+				$this->_errorMsg = $this->_connectionID->error ?? $this->_connectionID->connect_error;
+			}
 		}
 		return $this->_errorMsg;
 	}
@@ -1392,10 +1402,12 @@ class ADODB_mysqli extends ADOConnection {
 	 */
 	function ErrorNo()
 	{
-		if (empty($this->_connectionID)) {
-			$this->_errorCode = mysqli_connect_errno();
-		} else {
-			$this->_errorCode = $this->_connectionID->errno ?? $this->_connectionID->connect_errno;
+		if (!$this->_errorCode) {
+			if (empty($this->_connectionID)) {
+				$this->_errorCode = mysqli_connect_errno();
+			} else {
+				$this->_errorCode = $this->_connectionID->errno ?? $this->_connectionID->connect_errno;
+			}
 		}
 		return $this->_errorCode;
 	}


### PR DESCRIPTION
ADOConnection's errorNo() and errorMsg() methods were returning 0 / '' when executing an SQL statement with bound parameters, since the introduction of true prepared statements (in #655).

This is because they are getting error information from the mysqli connection object, but when using prepared statements, it must be retrieved from the mysqli_stmt object.

Fixes #872