### PR TITLE
silence deprecation warnings on oci connect

### DIFF
--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -289,7 +289,7 @@ END;
 			$argUsername,
 			$argPassword,
 			$argDatabasename,
-			$this->charSet ?: null,
+			$this->charSet ?: '',
 			$sessionMode
 		);
 		if (!$this->_connectionID) {


### PR DESCRIPTION
This silences following warnings.

```
Deprecated: oci_pconnect(): Passing null to parameter #4 ($encoding) of type string is deprecated
```
