### PR TITLE
revert primary_key default to unset

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -247,7 +247,7 @@ if (!defined('_ADODB_LAYER')) {
 		/**
 		 * @var bool True if field is a primary key
 		 */
-		public $primary_key = false;
+		public $primary_key;
 
 		/**
 		 * @var bool True if field is unique key


### PR DESCRIPTION
Introduction of the default value broke oci8 behavior. This PR seems to fix it.

The default "False" avoids to meet following `isset` condition,

https://github.com/ADOdb/ADOdb/blob/e3e3d14051dcd4d9203a12de87848a43a0687da4/adodb-active-record.inc.php#L451

And end up with "No primary key found for table" error.
