### PR TITLE
pgsql: fix "column already exists" error when adding a new column

### DIFF
--- a/datadict/datadict-postgres.inc.php
+++ b/datadict/datadict-postgres.inc.php
@@ -160,7 +160,8 @@ class ADODB2_postgres extends ADODB_DataDict
 		$sql = array();
 		$not_null = false;
 		list($lines,$pkey) = $this->_genFields($flds);
-		$alter = 'ALTER TABLE ' . $tabname . $this->addCol . ' ';
+		$alter = 'ALTER TABLE ' . $tabname . $this->addCol;
+		$alter .= (float)@$this->serverInfo['version'] < 9.6 ? ' ' : ' IF NOT EXISTS ';
 		foreach($lines as $v) {
 			if (($not_null = preg_match('/NOT NULL/i',$v))) {
 				$v = preg_replace('/NOT NULL/i','',$v);


### PR DESCRIPTION
This fix addresses the `column already exists` error for POSTGRESQL databases on an `ADD COLUMN` query. Executing a schema more than once will generate error messages due to the column already exists conflict. 

POSTGRESQL version 9.6 introduced the `IF NOT EXISTS` tag which can be used in order to skip situations like the one described above.

This Pull Request uses a condition in order to check for the client database version. If the version is greater or equal to 9.6 then it will insert the `IF NOT EXISTS` tag in the query.
