### PR TITLE
pdo: Creation of dynamic property deprecated warning in PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name" : "adodb/adodb-php",
+	"name" : "reportico/adodb-php",
 	"description" : "ADOdb is a PHP database abstraction layer library",
 	"license" : [ "BSD-3-Clause", "LGPL-2.1-or-later" ],
 	"authors" : [

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -82,7 +82,7 @@ class ADODB_pdo extends ADOConnection {
 	var $_errormsg = false;
 	var $_errorno = false;
 
-	var $stmt = false;
+	var $_stmt = false;
 	var $_driver;
 
 	/*
@@ -778,6 +778,7 @@ class ADORecordSet_pdo extends ADORecordSet {
 	var $bind = false;
 	var $databaseType = "pdo";
 	var $dataProvider = "pdo";
+	var $adodbFetchMode = false;
 
 	function __construct($id,$mode=false)
 	{


### PR DESCRIPTION
Fatal Error: drivers/adodb-pdo.inc.php Line 605 - Creation of dynamic property ADODB_pdo::$_stmt is deprecated
Fatal Error: drivers/adodb-pdo.inc.php Line 788 - Creation of dynamic property ADORecordSet_pdo::$adodbFetchMode is deprecated
