### PR TITLE
Add Bug Report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Submit a new bug report to help us improve ADOdb
 title: ''
-labels: ''
+labels: 'triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Submit a new bug report to help us improve ADOdb
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Description
+A clear and concise description of what the problem is, including relevant error messages and stack trace.
+
+### Environment
+- ADOdb version: _Version number (or Git Commit/Ref)_
+- Driver or Module: 
+- Database type and version: 
+- PHP version: 
+- Platform: 
+
+* [ ] I have tested that the problem is reproducible in the [latest release](https://github.com/ADOdb/ADOdb/releases/latest) / **master** branch / **hotfix** branch
+
+### Steps to reproduce
+Detailed, step-by-step instructions to reproduce the behavior, including:
+- code snippet 
+- SQL to create and populate database objects used by the code snippet
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+###Additional context 
+Add any other information relevant to the problem here.


### PR DESCRIPTION
This is leveraging Github's [Issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) feature. which should hopefully help improving the quality of the bug reports submitted by the community, as I find we frequently need to request the same additional information like ADOdb, PHP and DB type and version over and over again.

Let me know if you feel anything should be added or changed.

Note that we can also create a similar templates for *feature requests* and even a "custom" type, but we don't get that many of those so I'm not sure it's worth it. It's also possible for pull requests as well. Let me know if you think it any of these would be useful.