### PR TITLE
Remove obsolete error reporting operator(@)

### DIFF
--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -1350,7 +1350,14 @@ function _adodb_backtrace($printOrArr=true, $maximumDepth=9999, $elementsToIgnor
 			}
 		}
 		$s .= $arr['function'] . '(' . implode(', ', $args) . ')';
-		$s .= @sprintf($fmt, $arr['line'], $arr['file'], basename($arr['file']));
+
+		// Disable error reporting directly from the library. Report according
+		// to ADOdb debug configuration
+		error_reporting(0);
+		ini_set('display_errors',0);
+		$s .= sprintf($fmt, $arr['line'], $arr['file'], basename($arr['file']));
+		error_reporting(E_ALL);
+		ini_set('display_errors',1);
 		$s .= "\n";
 	}
 	if ($html) {

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -1547,7 +1547,13 @@ if (!defined('_ADODB_LAYER')) {
 			}
 			$this->_queryID = _adodb_debug_execute($this, $sql,$inputarr);
 		} else {
-			$this->_queryID = @$this->_query($sql,$inputarr);
+			// Disable error reporting directly from the library. Report according
+			// to ADOdb debug configuration
+			error_reporting(0);
+			ini_set('display_errors',0);
+			$this->_queryID = $this->_query($sql,$inputarr);
+			error_reporting(E_ALL);
+			ini_set('display_errors',1);
 		}
 
 		// ************************


### PR DESCRIPTION
Remove obsolete error reporting operator (@):

> Prior to PHP 8.0.0, the [error_reporting()](https://www.php.net/manual/en/function.error-reporting.php) called inside the custom error handler always returned 0 if the error was suppressed by the @ operator. As of PHP 8.0.0, it returns the value E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE.

## Reference
[Error Reporting Operator Manual](https://www.php.net/manual/en/language.operators.errorcontrol.php)