### PR TITLE
Fix MySQL Add Foreign Key query structure

### DIFF
--- a/datadict/datadict-mysql.inc.php
+++ b/datadict/datadict-mysql.inc.php
@@ -25,6 +25,7 @@ if (!defined('ADODB_DIR')) die();
 class ADODB2_mysql extends ADODB_DataDict {
 	var $databaseType = 'mysql';
 	var $alterCol = ' MODIFY COLUMN';
+	var $addFk = ' ADD FOREIGN KEY';
 	var $alterTableAddIndex = true;
 	var $dropTable = 'DROP TABLE IF EXISTS %s'; // requires mysql 3.22 or later
 


### PR DESCRIPTION
Currently the ADOdb produces an SQL query like the one below:
```sql
ALTER TABLE <tabname> MODIFY COLUMN (<fk_column_name>) <TYPE> REFERENCES <table>(<column>)
```
The correct syntax should be as follows:
```sql
ALTER TABLE <tabname> ADD FOREIGN KEY (<fk_column_name>) REFERENCES <table>(<column>)
```