### PR TITLE
Use globally-defined ADODB_FETCH_MODE if it is false on the object in getAssoc

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -4237,6 +4237,7 @@ class ADORecordSet implements IteratorAggregate {
 	 */
 	function getAssoc($force_array = false, $first2cols = false)
 	{
+		global $ADODB_FETCH_MODE;
 		/*
 		* Insufficient rows to show data
 		*/
@@ -4260,6 +4261,9 @@ class ADORecordSet implements IteratorAggregate {
 		* different than ADODB_FETCH_MODE
 		*/
 		$fetchMode = $this->connection->fetchMode;
+		if ($fetchMode === false) {
+			$fetchMode = $ADODB_FETCH_MODE;
+		}
 		if ($fetchMode == ADODB_FETCH_BOTH) {
 			/*
 			* If we are using BOTH, we present the data as if it


### PR DESCRIPTION
In my Ubuntu 22.10, I've come to an issue with the getAssoc function. 
It was a version 5.21.4, but i believe the current implementation did not fix the underlying issue.

I think that in case the connection fetchMode is `false`, the global `$ADODB_FETCH_MODE` should be used instead.