### PR TITLE
Fixed Partially-supported callable are deprecated in PHP 8.2

### DIFF
--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -234,7 +234,7 @@ class ADODB_pdo extends ADOConnection {
 			return call_user_func_array(array($this->_driver, 'Concat'), $args);
 		}
 
-		return call_user_func_array('parent::Concat', $args);
+		return call_user_func_array(parent::class . '::Concat', $args);
 	}
 
 	/**
@@ -254,7 +254,7 @@ class ADODB_pdo extends ADOConnection {
 		}
 
 		// No driver specific method defined, use mysql format '?'
-		return call_user_func_array('parent::param', $args);
+		return call_user_func_array(parent::class . '::param', $args);
 	}
 
 	// returns true or false


### PR DESCRIPTION
According to the PHP 8.2 documentation 
"parent::method" callables that are not consistent.
[Deprecated Callable Patterns](https://php.watch/versions/8.2/partially-supported-callable-deprecation#deprecated-patterns)

"parent::method"   	-> parent::class . "::method"