### PR TITLE
Suppress a PHP Notice

### DIFF
--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -691,7 +691,9 @@ class ADODB_postgres64 extends ADOConnection{
 		while ($row = $rs->FetchRow()) {
 			$columns = array();
 			foreach (explode(' ', $row[2]) as $col) {
-				$columns[] = $col_names[$col];
+				if (isset($col_names[$col])) {
+					$columns[] = $col_names[$col];
+				}
 			}
 
 			$indexes[$row[0]] = array(


### PR DESCRIPTION
When running our behat tests we are seeing a PHP Notice that we tracked down to this location.

It appears that `$col_names` is an array and it is not zero-indexed. We appear to have a `$row` of the form:
```
0: "behat_usr_fir_ix"
1: "f"
2: "0"
```
In this case `$row[2]` is just a "0" so the first `$col` is "0" and there is no `$col_names[0]`, hence the notice.

I admit that I'm not up to speed with what is happening here, and I don't know how or why this is coming about in the first place. But this fix doesn't appear to be breaking anything else and the scenario that this showed up in was one that starts with an empty database, builds the tables, does a *lot* of CRUD, and uninstalls the tables at the end.