### PR TITLE
912 sqlite deprecated creation of dynamic property adofieldobject%24scale is deprecated in driversadodb sqlite3incphp on line 194

### DIFF
--- a/adodb-datadict.inc.php
+++ b/adodb-datadict.inc.php
@@ -202,6 +202,12 @@ class ADODB_DataDict {
 	*/
 	public $blobAllowsDefaultValue;
 
+
+	/*
+	* string to use to quote identifiers and names
+	*/
+	public $quote;
+
 	function getCommentSQL($table,$col)
 	{
 		return false;

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -3966,6 +3966,10 @@ class ADORecordSet implements IteratorAggregate {
 	*/
 	protected $fieldObjectsIndex = array();
 
+	/*
+	* Defines the Fetch Mode for a recordset
+	*/
+	public $adodbFetchMode;
 
 	/**
 	 * Constructor

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -234,7 +234,7 @@ class ADODB_pdo extends ADOConnection {
 			return call_user_func_array(array($this->_driver, 'Concat'), $args);
 		}
 
-		return call_user_func_array('parent::Concat', $args);
+		return call_user_func_array(parent::class . '::Concat', $args);
 	}
 
 	/**
@@ -254,7 +254,7 @@ class ADODB_pdo extends ADOConnection {
 		}
 
 		// No driver specific method defined, use mysql format '?'
-		return call_user_func_array('parent::param', $args);
+		return call_user_func_array(parent::class . '::param', $args);
 	}
 
 	// returns true or false


### PR DESCRIPTION
Adds definitions in base classes for ''$quote'' and ''$adodbFetchMode''