### PR TITLE
Fix php81 deprecation warning

### DIFF
--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -853,6 +853,7 @@ class ADORecordSet_pdo extends ADORecordSet {
 
 	/** @var PDOStatement */
 	var $_queryID;
+	var $adodbFetchMode;
 
 	function __construct($id,$mode=false)
 	{

--- a/drivers/adodb-pdo.inc.php
+++ b/drivers/adodb-pdo.inc.php
@@ -87,6 +87,7 @@ class ADODB_pdo extends ADOConnection {
 	var $_errorno = false;
 
 	var $_stmt = false;
+	var $_stmt;
 
 	/** @var ADODB_pdo_base */
 	var $_driver;


### PR DESCRIPTION
On PHP 8.2 with php_pdo extensions in the errror log, you might see these warnings:

Deprecated in .../vendor/adodb/adodb-php/drivers/adodb-pdo.inc.php line 788: Creation of dynamic property ADORecordSet_pdo::$adodbFetchMode is deprecated

and 

Deprecated in /data/vendor/adodb/adodb-php/drivers/adodb-pdo.inc.php line 605: Creation of dynamic property ADODB_pdo::$_stmt is deprecated

That PR fixes that.