### PR TITLE
Minor fixes to avoid PHP warnings in v8.2+

### DIFF
--- a/adodb-csvlib.inc.php
+++ b/adodb-csvlib.inc.php
@@ -79,7 +79,6 @@ $ADODB_INCLUDED_CSV = 1;
 		$rs2 = new $class(ADORecordSet::DUMMY_QUERY_ID);
 		$rs2->timeCreated = $rs->timeCreated; # memcache fix
 		$rs2->sql = $rs->sql;
-		$rs2->oldProvider = $rs->dataProvider;
 		$rs2->InitArrayFields($rows,$flds);
 		$rs2->fetchMode = $savefetch;
 		return $line.serialize($rs2);

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -4023,10 +4023,8 @@ class ADORecordSet implements IteratorAggregate {
 	var $_atLastPage = false;	/** Added by Iván Oliva to implement recordset pagination */
 	var $_lastPageNo = -1;
 	var $_maxRecordCount = 0;
-	var $rowsPerPage;
 	var $datetime = false;
 
-	var $oldProvider;
 
 	public $customActualTypes;
 	public $customMetaTypes;
@@ -4067,10 +4065,7 @@ class ADORecordSet implements IteratorAggregate {
 	}
 
 	function __destruct() {
-		//If the _queryID is bogus, calling Close() may cause an error in the database driver.
-		if($this->_queryID != -1) {
-			$this->Close();
-		}
+		$this->Close();
 	}
 
 	#[\ReturnTypeWillChange]
@@ -4796,7 +4791,8 @@ class ADORecordSet implements IteratorAggregate {
 		// free connection object - this seems to globally free the object
 		// and not merely the reference, so don't do this...
 		// $this->connection = false;
-		if (!$this->_closed) {
+		// Also ensure the _queryID is not bogus, as calling Close() may cause an error in the database driver.
+		if (!$this->_closed && $this->_queryID != -1) {
 			$this->_closed = true;
 			return $this->_close();
 		} else

--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -4023,7 +4023,10 @@ class ADORecordSet implements IteratorAggregate {
 	var $_atLastPage = false;	/** Added by Iván Oliva to implement recordset pagination */
 	var $_lastPageNo = -1;
 	var $_maxRecordCount = 0;
+	var $rowsPerPage;
 	var $datetime = false;
+
+	var $oldProvider;
 
 	public $customActualTypes;
 	public $customMetaTypes;
@@ -4064,7 +4067,10 @@ class ADORecordSet implements IteratorAggregate {
 	}
 
 	function __destruct() {
-		$this->Close();
+		//If the _queryID is bogus, calling Close() may cause an error in the database driver.
+		if($this->_queryID != -1) {
+			$this->Close();
+		}
 	}
 
 	#[\ReturnTypeWillChange]

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -272,7 +272,7 @@ class ADODB_postgres64 extends ADOConnection{
 		if ($this->_connectionID) {
 			return "'" . pg_escape_string($this->_connectionID, $s) . "'";
 		} else {
-			//If there is no database connection, then pg_escape_string() will not work in PHP 8.3+.
+			//If there is no database connection, then pg_escape_string() will not work in PHP 8.1+.
 			//  This can occur when using setSessionVariables() in the load balancer, so fall back to emulated escaping in these cases.
 			return parent::qStr( $s );
 		}

--- a/drivers/adodb-postgres64.inc.php
+++ b/drivers/adodb-postgres64.inc.php
@@ -272,7 +272,9 @@ class ADODB_postgres64 extends ADOConnection{
 		if ($this->_connectionID) {
 			return "'" . pg_escape_string($this->_connectionID, $s) . "'";
 		} else {
-			return "'" . pg_escape_string($s) . "'";
+			//If there is no database connection, then pg_escape_string() will not work in PHP 8.3+.
+			//  This can occur when using setSessionVariables() in the load balancer, so fall back to emulated escaping in these cases.
+			return parent::qStr( $s );
 		}
 	}
 


### PR DESCRIPTION
Minor fixes to avoid PHP warnings in v8.2+.

See comments in code for further details if its not a simple object property initialization. 

