### PR TITLE
Fail connection if mysqlnd is not available

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,8 @@ Older changelogs:
   [#968](https://github.com/ADOdb/ADOdb/issues/968)
 - loadbalancer: PHP 8.2 warnings
   [#951](https://github.com/ADOdb/ADOdb/issues/951)
+- mysql: Fail connection if native driver (mysqlnd) is not available
+  [#967](https://github.com/ADOdb/ADOdb/issues/967)
 - pgsql: Fix PHP 8.1 deprecated warning
   [#956](https://github.com/ADOdb/ADOdb/issues/956)
 

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -167,6 +167,14 @@ class ADODB_mysqli extends ADOConnection {
 		if(!extension_loaded("mysqli")) {
 			return null;
 		}
+		// Check for a function that only exists in mysqlnd
+		if (!function_exists('mysqli_stmt_get_result')) {
+			// @TODO This will be treated as if the mysqli extension were not available
+			// This could be misleading, so we output an additional error message.
+			// We should probably throw a specific exception instead.
+			$this->outp("MySQL Native Driver (msqlnd) required");
+			return null;
+		}
 		$this->_connectionID = @mysqli_init();
 
 		if (is_null($this->_connectionID)) {


### PR DESCRIPTION
Since 5.22.0, the mysqli driver relies on the mysqli_stmt_get_result() function, which is only available in the MySQL Native Driver, to execute queries.

An attempt to connect on a system using libmysqlclient should fail with an error message, to avoid problems down the line.

Fixes #967