### PR TITLE
Set AllowDynamicProperties attribute on ADOFetchObj class.

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -3808,6 +3808,7 @@ http://www.stanford.edu/dept/itss/docs/oracle/10g/server.101/b10759/statements_1
 	/**
 	 * Internal placeholder for record objects. Used by ADORecordSet->FetchObj().
 	 */
+	#[\AllowDynamicProperties]
 	class ADOFetchObj {
 	};
 


### PR DESCRIPTION
Avoid deprecation warning on PHP 8.2.