### PR TITLE
Fixes #978 for ADOdb 5.21x

### DIFF
--- a/drivers/adodb-postgres8.inc.php
+++ b/drivers/adodb-postgres8.inc.php
@@ -47,9 +47,21 @@ class ADODB_postgres8 extends ADODB_postgres7
 	 */
 	protected function _insertID($table = '', $column = '')
 	{
-		return empty($table) || empty($column)
-			? $this->GetOne("SELECT lastval()")
-			: $this->GetOne("SELECT currval(pg_get_serial_sequence('$table', '$column'))");
+		global $ADODB_GETONE_EOF;
+
+		$sql = empty($table) || empty($column)
+			? 'SELECT lastval()'
+			: "SELECT currval(pg_get_serial_sequence('$table', '$column'))";
+
+		// Squelch "ERROR:  lastval is not yet defined in this session" (see #978)
+		$result = @$this->GetOne($sql);
+		if ($result === false || $result == $ADODB_GETONE_EOF) {
+			if ($this->debug) {
+				ADOConnection::outp(__FUNCTION__ . "() failed : " . $this->errorMsg());
+			}
+			return false;
+		}
+		return $result;
 	}
 }
 


### PR DESCRIPTION
 A backport of the #978 fix into the 5.21x ADOdb codebase.