### PR TITLE
Fixes #981 for ADOdb 5.21x

### DIFF
--- a/adodb-errorhandler.inc.php
+++ b/adodb-errorhandler.inc.php
@@ -37,7 +37,14 @@ if (!defined('ADODB_ERROR_HANDLER')) define('ADODB_ERROR_HANDLER','ADODB_Error_H
 */
 function ADODB_Error_Handler($dbms, $fn, $errno, $errmsg, $p1, $p2, &$thisConnection)
 {
-	if (error_reporting() == 0) return; // obey @ protocol
+	// Do not throw if errors are suppressed by @ operator
+	// error_reporting() value for suppressed errors changed in PHP 8.0.0
+	$suppressed = version_compare(PHP_VERSION, '8.0.0', '<')
+		? 0
+		: E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE;
+	if (error_reporting() == $suppressed) {
+		return;
+	}
 	switch($fn) {
 	case 'EXECUTE':
 		$sql = $p1;

--- a/adodb-errorpear.inc.php
+++ b/adodb-errorpear.inc.php
@@ -52,7 +52,14 @@ function ADODB_Error_PEAR($dbms, $fn, $errno, $errmsg, $p1=false, $p2=false)
 {
 global $ADODB_Last_PEAR_Error;
 
-	if (error_reporting() == 0) return; // obey @ protocol
+	// Do not throw if errors are suppressed by @ operator
+	// error_reporting() value for suppressed errors changed in PHP 8.0.0
+	$suppressed = version_compare(PHP_VERSION, '8.0.0', '<')
+		? 0
+		: E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE;
+	if (error_reporting() == $suppressed) {
+		return;
+	}
 	switch($fn) {
 	case 'EXECUTE':
 		$sql = $p1;

--- a/adodb-exceptions.inc.php
+++ b/adodb-exceptions.inc.php
@@ -77,7 +77,14 @@ function adodb_throw($dbms, $fn, $errno, $errmsg, $p1, $p2, $thisConnection)
 {
 global $ADODB_EXCEPTION;
 
-	if (error_reporting() == 0) return; // obey @ protocol
+	// Do not throw if errors are suppressed by @ operator
+	// error_reporting() value for suppressed errors changed in PHP 8.0.0
+	$suppressed = version_compare(PHP_VERSION, '8.0.0', '<')
+		? 0
+		: E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE;
+	if (error_reporting() == $suppressed) {
+		return;
+	}
 	if (is_string($ADODB_EXCEPTION)) $errfn = $ADODB_EXCEPTION;
 	else $errfn = 'ADODB_EXCEPTION';
 	throw new $errfn($dbms, $fn, $errno, $errmsg, $p1, $p2, $thisConnection);


### PR DESCRIPTION
A backport of the #981 fix for all error handlers into the 5.21x ADOdb codebase.