### PR TITLE
oci8: deprecation warning in selecLimit() on PHP 8.1

### DIFF
--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -805,7 +805,10 @@ END;
 		} else {
 			$hint = '';
 		}
-
+		// If non-bound statement, $inputarr is false
+		if (!$inputarr) {
+			$inputarr = array();
+		}
 		if ($offset == -1 || ($offset < $this->selectOffsetAlg1 && 0 < $nrows && $nrows < 1000)) {
 			if ($nrows > 0) {
 				if ($offset > 0) {
@@ -813,10 +816,6 @@ END;
 				}
 				$sql = "select * from (".$sql.") where rownum <= :adodb_offset";
 
-				// If non-bound statement, $inputarr is false
-				if (!$inputarr) {
-					$inputarr = array();
-				}
 				$inputarr['adodb_offset'] = $nrows;
 				$nrows = -1;
 			}


### PR DESCRIPTION
This is to prevent a PHP 8.2 warning