### PR TITLE
Closes #1016

### DIFF
--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -931,6 +931,9 @@ class ADODB_mysqli extends ADOConnection {
 				   AND table_name='$table'";
 
 		$schemaArray = $this->getAssoc($SQL);
+		if (!$schemaArray)
+			return $false;
+		
 		$schemaArray = array_change_key_case($schemaArray,CASE_LOWER);
 
 		$rs = $this->Execute(sprintf($this->metaColumnsSQL,$table));


### PR DESCRIPTION
Fixes Issue #1016 in the 5.22x branch.

It is expected that no result from getAssoc is caught before executing array_change_key_case so any code executed after this does not halt.