### PR TITLE
MySQL: adding ability to avoid use of bound variables and prepared statements

### DIFF
--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -78,6 +78,13 @@ class ADODB_mysqli extends ADOConnection {
 	var $ssl_capath = null;
 	var $ssl_cipher = null;
 
+	/**
+     * When set to true - ADODb will not use bound variables provided by the database driver and, instead, will use built-in string interpolation and argument quoting from the parent class.
+	 * Setting it to true is needed for some database engines that use mysql wire-protocol but don't support prepared statements like Manticore Search or ClickHouse.
+     * This is strongly discouraged for code handling untrusted input - see https://github.com/ADOdb/ADOdb/issues/1028#issuecomment-2081586024
+     */
+	var $doNotUseBoundVariables = false;
+
 	/** @var mysqli Identifier for the native database connection */
 	var $_connectionID = false;
 
@@ -1087,6 +1094,10 @@ class ADODB_mysqli extends ADOConnection {
 
 	public function execute($sql, $inputarr = false)
 	{
+
+		if ($this->doNotUseBoundVariables)              
+			return parent::execute($sql, $inputarr);
+		
 		if ($this->fnExecute) {
 			$fn = $this->fnExecute;
 			$ret = $fn($this, $sql, $inputarr);


### PR DESCRIPTION
…riables and prepared statements

Adding an option bringing mode of operation that was present in ADODb until v5.21.x ; v5.22.0 introduced use of bound variables and prepared statements which broke ADODb's compatibility with Manticore Search, ClickHouse

this is related to https://github.com/ADOdb/ADOdb/issues/1028