### PR TITLE
postgres: Issue when using schema+"" around table. Fix the name to "s…

### DIFF
--- a/adodb-lib.inc.php
+++ b/adodb-lib.inc.php
@@ -125,6 +125,13 @@ function _adodb_replace($zthis, $table, $fieldArray, $keyCol, $autoQuote, $has_a
 {
 	// Add Quote around table name to support use of spaces / reserved keywords
 	$table=sprintf('%s%s%s', $zthis->nameQuote,$table,$zthis->nameQuote);
+    if($zthis->dataProvider == "postgres" 
+      && substr($table,0,1) == '"' 
+      && substr($table,-1,1) == '"' 
+      && strstr($table,'.')) {
+        // handle postgresql "table" when using schema. "schema.table" is invalid, but "schema"."table" is OK.
+        $table = str_replace('.', '"."', $table);
+    }
 
 	if (count($fieldArray) == 0) return 0;
 


### PR DESCRIPTION
When using $autoQuote=true and having postrgesql schema, accessing table like "schema.table" will not work, because it is invalid name.
This pull request fixes that by making the name "schema"."table" which works.