### PR TITLE
MYSQLI SSL bug fixes

### DIFF
--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -231,9 +231,18 @@ class ADODB_mysqli extends ADOConnection {
 
 		// SSL Connections for MySQLI
 		if ($this->ssl_key || $this->ssl_cert || $this->ssl_ca || $this->ssl_capath || $this->ssl_cipher) {
+
 			mysqli_ssl_set($this->_connectionID, $this->ssl_key, $this->ssl_cert, $this->ssl_ca, $this->ssl_capath, $this->ssl_cipher);
-			$this->socket = MYSQLI_CLIENT_SSL;
-			$this->clientFlags = MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
+
+			// Check for set SSL client flag, NOTE: bitwise operations.
+			$ssl_client = ($this->clientFlags & MYSQLI_CLIENT_SSL);
+			$ssl_verify_cert = ($this->clientFlags & MYSQLI_CLIENT_SSL_VERIFY_SERVER_CERT);
+			$ssl_dont_verify_cert = ($this->clientFlags & MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT);
+
+			// Add SSL client flag to client flag(s) if not set, NOTE: bitwise operations.
+			if (!$ssl_client && !$ssl_verify_cert && !$ssl_dont_verify_cert) {
+				$this->clientFlags |= MYSQLI_CLIENT_SSL_VERIFY_SERVER_CERT;
+			}
 		}
 
 		$ok = @mysqli_real_connect($this->_connectionID,

--- a/drivers/adodb-mysqli.inc.php
+++ b/drivers/adodb-mysqli.inc.php
@@ -234,14 +234,10 @@ class ADODB_mysqli extends ADOConnection {
 
 			mysqli_ssl_set($this->_connectionID, $this->ssl_key, $this->ssl_cert, $this->ssl_ca, $this->ssl_capath, $this->ssl_cipher);
 
-			// Check for set SSL client flag, NOTE: bitwise operations.
-			$ssl_client = ($this->clientFlags & MYSQLI_CLIENT_SSL);
-			$ssl_verify_cert = ($this->clientFlags & MYSQLI_CLIENT_SSL_VERIFY_SERVER_CERT);
-			$ssl_dont_verify_cert = ($this->clientFlags & MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT);
-
-			// Add SSL client flag to client flag(s) if not set, NOTE: bitwise operations.
-			if (!$ssl_client && !$ssl_verify_cert && !$ssl_dont_verify_cert) {
-				$this->clientFlags |= MYSQLI_CLIENT_SSL_VERIFY_SERVER_CERT;
+			// Check for any SSL client flag set, NOTE: bitwise operation.
+			if (!($this->clientFlags & MYSQLI_CLIENT_SSL)) {
+        			ADOConnection::outp('When using certificates, set the client flag MYSQLI_CLIENT_SSL_VERIFY_SERVER_CERT or MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT');
+				return false;
 			}
 		}
 


### PR DESCRIPTION
I originally made the changes here https://github.com/ADOdb/ADOdb/pull/622 which caused some unfortunate issues that I didn't mean to happen, https://github.com/ADOdb/ADOdb/issues/919 I'd like to make changes to fix said issues I introduced. Removed inappropriate setting of socket, if a user wants to set a custom socket the user can set the class property, updates to only set the clientFlags to MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT if the clientFlags is set to the default 0 but the other ssl properties have been set specifying that the connection should be ssl.
