### PR TITLE
Enable DROP and RENAME COLUMN support for SQLite

### DIFF
--- a/datadict/datadict-sqlite.inc.php
+++ b/datadict/datadict-sqlite.inc.php
@@ -91,16 +91,4 @@ class ADODB2_sqlite extends ADODB_DataDict {
 		return array();
 	}
 
-	function DropColumnSQL($tabname, $flds, $tableflds='', $tableoptions='')
-	{
-		if ($this->debug) ADOConnection::outp("DropColumnSQL not supported natively by SQLite");
-		return array();
-	}
-
-	function RenameColumnSQL($tabname,$oldcolumn,$newcolumn,$flds='')
-	{
-		if ($this->debug) ADOConnection::outp("RenameColumnSQL not supported natively by SQLite");
-		return array();
-	}
-
 }


### PR DESCRIPTION
SQlite now supports a subset of [ALTER TABLE](https://www.sqlite.org/lang_altertable.html) operations with some limitations. I think it's up to the user to decide how to use it, and the capability should be there anyway.