### PR TITLE
Fulfill the SQLite PRIMARY KEY AUTOINCREMENT requirements.

### DIFF
--- a/adodb-datadict.inc.php
+++ b/adodb-datadict.inc.php
@@ -843,7 +843,7 @@ class ADODB_DataDict {
 						$fdefault = $this->connection->qstr($fdefault);
 				}
 			}
-			$suffix = $this->_createSuffix($fname,$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned);
+			$suffix = $this->_CreateSuffix($fname,$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,$pkey);
 
 			// add index creation
 			if ($widespacing) $fname = str_pad($fname,24);
@@ -897,7 +897,7 @@ class ADODB_DataDict {
 
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/adodb-datadict.inc.php
+++ b/adodb-datadict.inc.php
@@ -843,7 +843,7 @@ class ADODB_DataDict {
 						$fdefault = $this->connection->qstr($fdefault);
 				}
 			}
-			$suffix = $this->_CreateSuffix($fname,$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,$pkey);
+			$suffix = $this->_createSuffix($fname,$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,$pkey);
 
 			// add index creation
 			if ($widespacing) $fname = str_pad($fname,24);
@@ -897,7 +897,7 @@ class ADODB_DataDict {
 
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/adodb-datadict.inc.php
+++ b/adodb-datadict.inc.php
@@ -853,7 +853,7 @@ class ADODB_DataDict {
 						$fdefault = $this->connection->qstr($fdefault);
 				}
 			}
-			$suffix = $this->_createSuffix($fname,$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,$pkey);
+			$suffix = $this->_createSuffix($fname, $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, $pkey);
 
 			// add index creation
 			if ($widespacing) $fname = str_pad($fname,24);
@@ -906,8 +906,22 @@ class ADODB_DataDict {
 	}
 
 
-	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	/**
+	 * Construct an database specific SQL string of constraints for column.
+	 *
+	 * @param string $fname         column name
+	 * @param string & $ftype       column type
+	 * @param bool   $fnotnull      NOT NULL flag
+	 * @param string|bool $fdefault DEFAULT value
+	 * @param bool   $fautoinc      AUTOINCREMENT flag
+	 * @param string $fconstraint   CONSTRAINT value
+	 * @param bool   $funsigned     UNSIGNED flag
+	 * @param string|bool $fprimary PRIMARY value
+	 * @param array  & $pkey        array of primary key column names
+	 *
+	 * @return string Combined constraint string, must start with a space
+	 */
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/datadict/datadict-access.inc.php
+++ b/datadict/datadict-access.inc.php
@@ -69,7 +69,7 @@ class ADODB2_access extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		if ($fautoinc) {
 			$ftype = 'COUNTER';

--- a/datadict/datadict-access.inc.php
+++ b/datadict/datadict-access.inc.php
@@ -69,7 +69,7 @@ class ADODB2_access extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname, &$ftype, $fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		if ($fautoinc) {
 			$ftype = 'COUNTER';

--- a/datadict/datadict-access.inc.php
+++ b/datadict/datadict-access.inc.php
@@ -69,7 +69,7 @@ class ADODB2_access extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		if ($fautoinc) {
 			$ftype = 'COUNTER';

--- a/datadict/datadict-db2.inc.php
+++ b/datadict/datadict-db2.inc.php
@@ -72,7 +72,7 @@ class ADODB2_db2 extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if ($fautoinc) return ' GENERATED ALWAYS AS IDENTITY'; # as identity start with

--- a/datadict/datadict-db2.inc.php
+++ b/datadict/datadict-db2.inc.php
@@ -72,7 +72,7 @@ class ADODB2_db2 extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		$suffix = '';
 		if ($fautoinc) return ' GENERATED ALWAYS AS IDENTITY'; # as identity start with

--- a/datadict/datadict-db2.inc.php
+++ b/datadict/datadict-db2.inc.php
@@ -72,7 +72,7 @@ class ADODB2_db2 extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if ($fautoinc) return ' GENERATED ALWAYS AS IDENTITY'; # as identity start with

--- a/datadict/datadict-firebird.inc.php
+++ b/datadict/datadict-firebird.inc.php
@@ -135,7 +135,7 @@ class ADODB2_firebird extends ADODB_DataDict
 	}
 
 
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 

--- a/datadict/datadict-firebird.inc.php
+++ b/datadict/datadict-firebird.inc.php
@@ -135,7 +135,7 @@ class ADODB2_firebird extends ADODB_DataDict
 	}
 
 
-	function _createSuffix($fname, &$ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 

--- a/datadict/datadict-firebird.inc.php
+++ b/datadict/datadict-firebird.inc.php
@@ -135,7 +135,7 @@ class ADODB2_firebird extends ADODB_DataDict
 	}
 
 
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		$suffix = '';
 

--- a/datadict/datadict-informix.inc.php
+++ b/datadict/datadict-informix.inc.php
@@ -81,7 +81,7 @@ class ADODB2_informix extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname, &$ftype, $fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		if ($fautoinc) {
 			$ftype = 'SERIAL';

--- a/datadict/datadict-informix.inc.php
+++ b/datadict/datadict-informix.inc.php
@@ -81,7 +81,7 @@ class ADODB2_informix extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		if ($fautoinc) {
 			$ftype = 'SERIAL';

--- a/datadict/datadict-informix.inc.php
+++ b/datadict/datadict-informix.inc.php
@@ -81,7 +81,7 @@ class ADODB2_informix extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		if ($fautoinc) {
 			$ftype = 'SERIAL';

--- a/datadict/datadict-mssql.inc.php
+++ b/datadict/datadict-mssql.inc.php
@@ -177,7 +177,7 @@ class ADODB2_mssql extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/datadict/datadict-mssql.inc.php
+++ b/datadict/datadict-mssql.inc.php
@@ -177,7 +177,7 @@ class ADODB2_mssql extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/datadict/datadict-mssql.inc.php
+++ b/datadict/datadict-mssql.inc.php
@@ -177,7 +177,7 @@ class ADODB2_mssql extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/datadict/datadict-mssqlnative.inc.php
+++ b/datadict/datadict-mssqlnative.inc.php
@@ -269,7 +269,7 @@ class ADODB2_mssqlnative extends ADODB_DataDict {
 	// return string must begin with space
 
 	/** @noinspection DuplicatedCode */
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/datadict/datadict-mssqlnative.inc.php
+++ b/datadict/datadict-mssqlnative.inc.php
@@ -269,7 +269,7 @@ class ADODB2_mssqlnative extends ADODB_DataDict {
 	// return string must begin with space
 
 	/** @noinspection DuplicatedCode */
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/datadict/datadict-mssqlnative.inc.php
+++ b/datadict/datadict-mssqlnative.inc.php
@@ -269,7 +269,7 @@ class ADODB2_mssqlnative extends ADODB_DataDict {
 	// return string must begin with space
 
 	/** @noinspection DuplicatedCode */
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/datadict/datadict-mysql.inc.php
+++ b/datadict/datadict-mysql.inc.php
@@ -143,7 +143,7 @@ class ADODB2_mysql extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if ($funsigned) $suffix .= ' UNSIGNED';

--- a/datadict/datadict-mysql.inc.php
+++ b/datadict/datadict-mysql.inc.php
@@ -143,7 +143,7 @@ class ADODB2_mysql extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		$suffix = '';
 		if ($funsigned) $suffix .= ' UNSIGNED';

--- a/datadict/datadict-mysql.inc.php
+++ b/datadict/datadict-mysql.inc.php
@@ -143,7 +143,7 @@ class ADODB2_mysql extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if ($funsigned) $suffix .= ' UNSIGNED';

--- a/datadict/datadict-oci8.inc.php
+++ b/datadict/datadict-oci8.inc.php
@@ -199,7 +199,7 @@ class ADODB2_oci8 extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 

--- a/datadict/datadict-oci8.inc.php
+++ b/datadict/datadict-oci8.inc.php
@@ -199,7 +199,7 @@ class ADODB2_oci8 extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		$suffix = '';
 

--- a/datadict/datadict-oci8.inc.php
+++ b/datadict/datadict-oci8.inc.php
@@ -199,7 +199,7 @@ class ADODB2_oci8 extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 

--- a/datadict/datadict-postgres.inc.php
+++ b/datadict/datadict-postgres.inc.php
@@ -399,7 +399,7 @@ class ADODB2_postgres extends ADODB_DataDict
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname, &$ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		if ($fautoinc) {
 			$ftype = 'SERIAL';

--- a/datadict/datadict-postgres.inc.php
+++ b/datadict/datadict-postgres.inc.php
@@ -399,7 +399,7 @@ class ADODB2_postgres extends ADODB_DataDict
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		if ($fautoinc) {
 			$ftype = 'SERIAL';

--- a/datadict/datadict-postgres.inc.php
+++ b/datadict/datadict-postgres.inc.php
@@ -399,7 +399,7 @@ class ADODB2_postgres extends ADODB_DataDict
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		if ($fautoinc) {
 			$ftype = 'SERIAL';

--- a/datadict/datadict-sapdb.inc.php
+++ b/datadict/datadict-sapdb.inc.php
@@ -104,7 +104,7 @@ class ADODB2_sapdb extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if ($funsigned) $suffix .= ' UNSIGNED';

--- a/datadict/datadict-sapdb.inc.php
+++ b/datadict/datadict-sapdb.inc.php
@@ -104,7 +104,7 @@ class ADODB2_sapdb extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if ($funsigned) $suffix .= ' UNSIGNED';

--- a/datadict/datadict-sapdb.inc.php
+++ b/datadict/datadict-sapdb.inc.php
@@ -104,7 +104,7 @@ class ADODB2_sapdb extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		$suffix = '';
 		if ($funsigned) $suffix .= ' UNSIGNED';

--- a/datadict/datadict-sqlite.inc.php
+++ b/datadict/datadict-sqlite.inc.php
@@ -84,17 +84,16 @@ class ADODB2_sqlite extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		$suffix = '';
 		if ($funsigned && !($fprimary && $fautoinc)) $suffix .= ' UNSIGNED';
 		if ($fnotnull) $suffix .= ' NOT NULL';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";
 		if ($fprimary && $fautoinc) {
-			$suffix .= ' PRIMARY KEY';
+			$suffix .= ' PRIMARY KEY AUTOINCREMENT';
 			array_pop($pkey);
 		}
-		if ($fautoinc) $suffix .= ' AUTOINCREMENT';
 		if ($fconstraint) $suffix .= ' '.$fconstraint;
 		return $suffix;
 	}

--- a/datadict/datadict-sqlite.inc.php
+++ b/datadict/datadict-sqlite.inc.php
@@ -74,12 +74,16 @@ class ADODB2_sqlite extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
-		if ($funsigned) $suffix .= ' UNSIGNED';
+		if ($funsigned && !($fprimary && $fautoinc)) $suffix .= ' UNSIGNED';
 		if ($fnotnull) $suffix .= ' NOT NULL';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";
+		if ($fprimary && $fautoinc) {
+			$suffix .= ' PRIMARY KEY';
+			array_pop($pkey);
+		}
 		if ($fautoinc) $suffix .= ' AUTOINCREMENT';
 		if ($fconstraint) $suffix .= ' '.$fconstraint;
 		return $suffix;

--- a/datadict/datadict-sqlite.inc.php
+++ b/datadict/datadict-sqlite.inc.php
@@ -74,7 +74,7 @@ class ADODB2_sqlite extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if ($funsigned && !($fprimary && $fautoinc)) $suffix .= ' UNSIGNED';

--- a/datadict/datadict-sybase.inc.php
+++ b/datadict/datadict-sybase.inc.php
@@ -139,7 +139,7 @@ class ADODB2_sybase extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/datadict/datadict-sybase.inc.php
+++ b/datadict/datadict-sybase.inc.php
@@ -139,7 +139,7 @@ class ADODB2_sybase extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _createSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
+	function _createSuffix($fname, & $ftype, $fnotnull, $fdefault, $fautoinc, $fconstraint, $funsigned, $fprimary, & $pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";

--- a/datadict/datadict-sybase.inc.php
+++ b/datadict/datadict-sybase.inc.php
@@ -139,7 +139,7 @@ class ADODB2_sybase extends ADODB_DataDict {
 	}
 
 	// return string must begin with space
-	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned)
+	function _CreateSuffix($fname,&$ftype,$fnotnull,$fdefault,$fautoinc,$fconstraint,$funsigned,$fprimary,&$pkey)
 	{
 		$suffix = '';
 		if (strlen($fdefault)) $suffix .= " DEFAULT $fdefault";


### PR DESCRIPTION
This patch extends ADODB_DataDict::_CreateSuffix() with two additional parameters - `$fprimary` (PRIMARY KEY flag) and `& $pkey` (reference to array of primary keys). The ADODB2_sqlite::_CreateSuffix() has been modified to do a special processing of the PRIMARY KEY AUTOINCREMENT column to make SQLite happy and accept this syntax.

This required for MantisBT [PR 2055](https://github.com/mantisbt/mantisbt/pull/2055).
