### PR TITLE
PDO Firebird driver extends ADODB_pdo_base

### DIFF
--- a/drivers/adodb-pdo_firebird.inc.php
+++ b/drivers/adodb-pdo_firebird.inc.php
@@ -24,7 +24,7 @@
 /**
  * Class ADODB_pdo_firebird
  */
-class ADODB_pdo_firebird extends ADODB_pdo
+class ADODB_pdo_firebird extends ADODB_pdo_base
 {
 	public $dialect = 3;
 	public $metaTablesSQL = "select lower(rdb\$relation_name) from rdb\$relations where rdb\$relation_name not like 'RDB\$%'";


### PR DESCRIPTION
Previously, it inherited from ADODB_pdo, which caused Fatal error: Uncaught Error: Call to undefined method ADODB_pdo_firebird::_init().

Fixes #1122