### PR TITLE
Fixes ADOdb/ADOdb#1146

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -2760,15 +2760,16 @@ if (!defined('_ADODB_LAYER')) {
 		}
 
 		$sql = "SELECT * FROM $table";
+		if (!empty($where)) {
+			$sql .= " WHERE $where";
+		}
+
 		$rs = $this->SelectLimit($sql, 1);
 		if (!$rs) {
 			return false; // table does not exist
 		}
 
 		$rs->tableName = $table;
-		if (!empty($where)) {
-			$sql .= " WHERE $where";
-		}
 		$rs->sql = $sql;
 
 		switch($mode) {

--- a/tests/test-autoexecute-update.php
+++ b/tests/test-autoexecute-update.php
@@ -1,0 +1,28 @@
+<?php
+
+require __DIR__ . "/../adodb.inc.php";
+
+$db = NewADOConnection("sqlite3");
+$db->Connect(":memory:");
+
+$db->Execute("CREATE TABLE users(id primary key, name, year_of_birth)");
+$db->Execute("INSERT INTO users VALUES (1, 'John', 2000)");
+$db->Execute("INSERT INTO users VALUES (2, 'Jane', 1981)");
+
+$new_value = 2000;
+
+$db->autoExecute(
+    table: "users",
+    fields_values: ["year_of_birth" => $new_value],
+    mode: "UPDATE",
+    where: "id = 2",
+    forceUpdate: false,
+);
+
+$updated_value = $db->GetOne("SELECT year_of_birth FROM users WHERE id = 2");
+
+if ($updated_value != $new_value) {
+    die("ERROR: updated_value $updated_value != new_value $new_value");
+}
+
+echo "Finished.\n";


### PR DESCRIPTION
AutoExecute fetches a row from the table prior to performing an insert or update. When forceUpdate is false, only modified columns should be updated. However, the WHERE clause was not being used when fetching the row, so the comparison was always made against an arbitrary row, causing differences to be detected or missed by chance.

This change makes use of the $where parameter when fetching the row from the table, making the comparison work as intended.

Fixes #1146 