### PR TITLE
Fix metaTables() for SQLite3

### DIFF
--- a/drivers/adodb-pdo_sqlite.inc.php
+++ b/drivers/adodb-pdo_sqlite.inc.php
@@ -23,7 +23,7 @@
 
 class ADODB_pdo_sqlite extends ADODB_pdo_base {
 	/** @noinspection SqlResolve */
-	var $metaTablesSQL   = "SELECT name FROM sqlite_master WHERE type='table'";
+	var $metaTablesSQL   = "SELECT name,CASE WHEN type='table' THEN 'T' ELSE 'V' END FROM sqlite_master WHERE type IN('table','view') AND name NOT LIKE 'sqlite_%'";
 	var $sysDate         = 'current_date';
 	var $sysTimeStamp    = 'current_timestamp';
 	var $nameQuote       = '`';

--- a/drivers/adodb-sqlite.inc.php
+++ b/drivers/adodb-sqlite.inc.php
@@ -35,7 +35,7 @@ class ADODB_sqlite extends ADOConnection {
 	var $hasLimit = true;
 	var $hasInsertID = true; 		/// supports autoincrement ID?
 	var $hasAffectedRows = true; 	/// supports affected rows for update/delete?
-	var $metaTablesSQL = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name";
+	var $metaTablesSQL = "SELECT name,CASE WHEN type='table' THEN 'T' ELSE 'V' END FROM sqlite_master WHERE type IN('table','view') AND name NOT LIKE 'sqlite_%'";
 	var $sysDate = "date('Y-m-d')";
 	var $sysTimeStamp = "date('Y-m-d H:i:s')";
 	var $fmtTimeStamp = "'Y-m-d H:i:s'";

--- a/drivers/adodb-sqlite3.inc.php
+++ b/drivers/adodb-sqlite3.inc.php
@@ -38,7 +38,7 @@ class ADODB_sqlite3 extends ADOConnection {
 	var $hasLimit = true;
 	var $hasInsertID = true; 		/// supports autoincrement ID?
 	var $hasAffectedRows = true; 	/// supports affected rows for update/delete?
-	var $metaTablesSQL = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name";
+	var $metaTablesSQL = "SELECT name,CASE WHEN type='table' THEN 'T' ELSE 'V' END FROM sqlite_master WHERE type IN('table','view') AND name NOT LIKE 'sqlite_%'";
 	var $sysDate = "DATE('now','localtime')";
 	var $sysTimeStamp = "DATETIME('now','localtime')";
 	var $fmtTimeStamp = "'Y-m-d H:i:s'";


### PR DESCRIPTION
The SELECT call used in the metaTables() function must return a dataset with two columns: the name of the table or view and the type 'T' or 'V'.

This PR is needed for https://github.com/mantisbt/mantisbt/pull/2055
