### PR TITLE
PHP8.4 Causes Deprecation Warning in adodb-csvlib.inc.php

### DIFF
--- a/adodb-csvlib.inc.php
+++ b/adodb-csvlib.inc.php
@@ -110,7 +110,7 @@ $ADODB_INCLUDED_CSV = 1;
 		$arr = array();
 		$ttl = 0;
 
-		if ($meta = fgetcsv($fp, 32000, ",")) {
+		if ($meta = fgetcsv($fp, 32000, ",", '"', "\\")) {
 			// check if error message
 			if (strncmp($meta[0],'****',4) === 0) {
 				$err = trim(substr($meta[0],4,1024));
@@ -214,7 +214,7 @@ $ADODB_INCLUDED_CSV = 1;
 				}
 
 				$meta = false;
-				$meta = fgetcsv($fp, 32000, ",");
+				$meta = fgetcsv($fp, 32000, ",", '"');
 				if (!$meta) {
 					fclose($fp);
 					$err = "Unexpected EOF 1";


### PR DESCRIPTION
Fixes the deprecation warnings caused by missing 4th parameter in fgetcsv function calls