### PR TITLE
Change the output of MetaForeignKeys

### DIFF
--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -1549,7 +1549,7 @@ SELECT /*+ RULE */ distinct b.column_name
 	 * @param bool   $upper       Return keys in uppercase (true)
 	 * @param bool   $associative Force associative mode
 	 *
-	 * @return array|false An array where keys are tables, and values are foreign keys;
+	 * @return string[]|false An array where keys are tables, and values are foreign keys;
 	 *                     false if no foreign keys could be found.
 	 */
 	public function metaForeignKeys($table, $owner = '', $upper = false, $associative = false)


### PR DESCRIPTION
- Remove the PHP8.5 deprecation warning
 - Add support for forceAssociative and Uppercase options
 - Ensure that the returned format conforms to the documented standard