### PR TITLE
Move the cachedSchemaFlush property from mssqlnative to core

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -756,6 +756,15 @@ if (!defined('_ADODB_LAYER')) {
 	/** @var string a specified locale. */
 	var $locale;
 
+	/**
+	 * Setting true forces metacolumns to be read the db for 
+	 * each access of a table instead of using cached version. 
+	 * Currently only works on mssqlnative
+	 * 
+	 * @var bool
+	 */
+	public bool $cachedSchemaFlush = false;
+	
 
 	/**
 	 * Default Constructor.

--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -100,7 +100,6 @@ class ADODB_mssqlnative extends ADOConnection {
 	var $_dropSeqSQL = "DROP SEQUENCE %s";
 
 	var $connectionInfo    = array('ReturnDatesAsStrings'=>true);
-	var $cachedSchemaFlush = false;
 
 	var $sequences = false;
 	var $mssql_version = '';


### PR DESCRIPTION
This prevents dynamic property warnings when a portable application is written that accesses the property from a non-mssqlnative driver