### PR TITLE
Fixes #885 Inconsistent data returned from getAssoc() when fetch mode is ADODB_FETCH_BOTH

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -4506,6 +4506,11 @@ class ADORecordSet implements IteratorAggregate {
 	{
 		global $ADODB_FETCH_MODE;
 
+		/*
+		* Filters mode to single value
+		*/
+		$selfFetchMode = $this->connection->fetchMode === false ? $ADODB_FETCH_MODE : $this->connection->fetchMode;
+		
 		// Insufficient rows to show data
 		if ($this->_numOfFields < 2) {
 			return false;
@@ -4516,79 +4521,84 @@ class ADORecordSet implements IteratorAggregate {
 			return array();
 		}
 
-		// The number of fields is half the actual returned in BOTH mode
-		$numberOfFields = $this->_numOfFields;
-
-		// Get the fetch mode when the call was executed, this may be
-		// different from ADODB_FETCH_MODE
-		$fetchMode = $this->adodbFetchMode;
-		if ($fetchMode == ADODB_FETCH_BOTH || $fetchMode == ADODB_FETCH_DEFAULT) {
-			// If we are using BOTH, we present the data as if it were in ASSOC mode.
-			// This could be enhanced by adding a BOTH_ASSOC_MODE class property.
-			// We build a template of numeric keys. you could improve the speed
-			// by caching this, indexed by number of keys.
-			$testKeys = array_fill(0, $numberOfFields, 0);
-		}
-
-		$showArrayMethod = 0;
-
-		if ($numberOfFields == 2) {
-			// Key is always the value of first element
-			// Value is always value of second element
-			$showArrayMethod = 1;
-		}
-
-		if ($force_array) {
-			$showArrayMethod = 0;
-		}
-
-		if ($first2cols) {
-			$showArrayMethod = 1;
-		}
-
-		$results = array();
+		$results = [];
 
 		while (!$this->EOF) {
-			$myFields = $this->fields;
 
-			if ($fetchMode == ADODB_FETCH_BOTH || $fetchMode == ADODB_FETCH_DEFAULT) {
-				// extract the associative keys
-				/** @noinspection PhpUndefinedVariableInspection */
-				$myFields = array_diff_key($myFields, $testKeys);
+			if ($this->_numOfFields == 2) {
+				/*
+				* Fetch both returns half fields fetched
+				*/
+				$first2cols = true;
 			}
 
-			// Key is value of the first element, the rest is data.
-			// The key is not case processed.
-			$key = array_shift($myFields);
+			/*
+			* Allows easier cross-referencing keys to values
+			* when we don't know the name of the column
+			*/
+			$pairKeys   = array_keys($this->fields);
+			$pairValues = array_values($this->fields);	
+			
+			switch($selfFetchMode) {
 
-			switch ($showArrayMethod) {
-				case 0:
-					if ($fetchMode != ADODB_FETCH_NUM) {
-						// The driver should have already handled the key casing, but in case it did not.
-						// We will check and force this in later versions of ADOdb
-						if (ADODB_ASSOC_CASE == ADODB_ASSOC_CASE_UPPER) {
-							$myFields = array_change_key_case($myFields, CASE_UPPER);
-						}
-						elseif (ADODB_ASSOC_CASE == ADODB_ASSOC_CASE_LOWER) {
-							$myFields = array_change_key_case($myFields, CASE_LOWER);
-						}
+			case ADODB_FETCH_ASSOC:
+				
+				$key        = $pairValues[0];
+				$flatValue  = $pairValues[1];
+				
+				$forceArrayValue = [ 
+					$pairKeys[0] => $pairValues[0],
+					$pairKeys[1] => $pairValues[1]
+				];
+				break;
+			
+			case ADODB_FETCH_NUM:
+				
+				$key 	   = $this->fields[0];
+				$flatValue = $this->fields[1];
+				
+				$forceArrayValue = [ 
+					0 => $pairValues[0],
+					1 => $pairValues[1]
+				];
+				break;
+			
+			case ADODB_FETCH_BOTH:
 
-						// We have already shifted the key off the front, so the rest is the value
-						$results[$key] = $myFields;
-					} else
-						// I want the values in a numeric array, nicely re-indexed from zero
-						$results[$key] = array_values($myFields);
-					break;
+				$key 	   = $this->fields[0];
+				$flatValue = $this->fields[1];
 
-				/** @noinspection PhpConditionAlreadyCheckedInspection */
-				case 1:
-					// Don't care how long the array is, I just want value of second column,
-					// and it doesn't matter whether the array is associative or numeric
-					$results[$key] = array_shift($myFields);
-					break;
+				$forceArrayValue = [
+					$pairKeys[0] => $pairValues[0],
+					$pairKeys[1] => $pairValues[1],
+					$pairKeys[2] => $pairValues[2],
+					$pairKeys[3] => $pairValues[3]
+				];
+
+				break;
+			} 
+
+			if (!$force_array && $first2cols) {
+				/*
+				* Default behavior key/value pair
+				*/
+				$results[$key] = $flatValue;
+
+			} else if ($force_array && $first2cols) {
+				
+				/*
+				* Pair 1 array has 2 key value pairs(4 in both)
+				*/
+				$results[$key] = $forceArrayValue;
+			
+			} else {
+				/*
+				* >2 Columns, no constrints
+				*/
+				$results[$key] = $this->fields;
 			}
 
-			$this->MoveNext();
+			$this->moveNext();
 		}
 
 		return $results;


### PR DESCRIPTION


Fixes #885 Restructuring how data is returned when the Fetch mode is **ADODB_FETCH_BOTH**

Going back to Version 5.20.0 it is difficult to determine what the desired response is supposed to be for this method when the `forceArray` flag is set. This is amplified for data returned when the fetch mode is **ADODB_FETCH_BOTH**. There is no single version of the method that does not return a faulty response when one of many flag combinations is set.

Because the method allows both connection-based access ``$db->getAssoc()`` and a recordset-based access ``$db->execute()->getAssoc()`` it is impossible to provide a standardized response like other connection-based methods. 

While there are no ambiguities in the data format when the ``forceArray`` flag is not set, the current behaviour of method using the flag is confusing and inconsistent.  These examples show the problem.
A recordset has the columns:
<table>
<tr><th>col_0</th><th>col_1</th><th>col_2</tr>
<tr><td>1</td><td>A</td><td>X</td></tr>
<tr><td>2</td><td>B</td><td>Y</td></tr>
<tr><td>3</td><td>C</td><td>Z</td></tr>
</table>

When **forceArray** is false, a consistent result occurs. The first column is always dropped from the value 
````php
Array
(
    1 =>[ 'A', 'X']
    2 => ['B', 'Y']
    3 => ['C', 'Z']
);
````
But when the **forceArray** flag is set, then inconsistent results occur. 
````php
// ADODB_FETCH_NUM
Array
(
  1 => [1 => 'A', 2 => 'X'],
  2 => [1 => 'B', 2 => 'Y'],
  3 => [1 => 'C', 2 => 'Z']
)
// ADODB_FETCH_ASSOC
Array
(
  1 => ['col_1' => 'A', 'col_2' => 'X'],
  2 => ['col_1' => 'B', 'col_2' => 'Y'],
  3 => ['col_1' => 'C', 'col_2' => 'Z']
)
// ADODB_FETCH_BOTH
Array
(
  1 => ['col_0' => 1, 1 => 'A', col_1' => 'A',2 => 'X', 'col_3' => 'X'],
  2 => ['col_0' => 2, 1 => 'B', col_1' => 'B',2 => 'Y', 'col_3' => 'Y'],
  3 => ['col_0' => 3, 1 => 'C', col_1' => 'C',2 => 'Z', 'col_3' => 'Z'],
)
````
This effect is achieved by shifting the first element of the data array off of the returned data. Of course, because in FETCH_BOTH mode, each element is returned twice, which leaves the associative portion of the first element of the array on the data array. Incidentally, the DB2 driver returns the data with the Associative portion first, so the first element is the numeric portion:
````php
Array
(
  1 => [0 => 1, col_1' => 'A', 1 => 'A', 'col_3' => 'X',2 => 'X'],
````
### Solution
Looking at the 5.20 code, it appears that when the **forceArray** flag is set, all data elements are set, so the returned recordset would look like this:

````php
// ADODB_FETCH_NUM
Array
(
  1 => [0 => 1, 1 => 'A', 2 => 'X'],
  2 => [0 => 2, 1 => 'B', 2 => 'Y'],
  3 => [0 => 3, 1 => 'C', 2 => 'Z']
)
// ADODB_FETCH_ASSOC
Array
(
  1 => ['col_0' => 1, 'col_1' => 'A', 'col_2' => 'X'],
  2 => ['col_0' => 2, 'col_1' => 'B', 'col_2' => 'Y'],
  3 => ['col_0' => 3, 'col_1' => 'C', 'col_2' => 'Z']
)
// ADODB_FETCH_BOTH
Array
(
  1 => [0 => 1, 'col_0' => 1, 1 => 'A', col_1' => 'A',2 => 'X', 'col_3' => 'X'],
  2 => [0 => 2, 'col_0' => 2, 1 => 'B', col_1' => 'B',2 => 'Y', 'col_3' => 'Y'],
  3 => [0 => 3, 'col_0' => 3, 1 => 'C', col_1' => 'C',2 => 'Z', 'col_3' => 'Z'],
)
````
This produces a consistent result, but is this a breaking change for existing users. Without understanding the use of the option, it is difficult to say
