### PR TITLE
Fix #606 Regression error retrieving affected_rows in SQL Server

### DIFF
--- a/drivers/adodb-mssqlnative.inc.php
+++ b/drivers/adodb-mssqlnative.inc.php
@@ -69,7 +69,7 @@ class ADODB_mssqlnative extends ADOConnection {
 	 *
 	 * @var bool|int
 	 */
-	public mixed $affectedRowCount = false;
+	public $affectedRowCount = false;
 
 	/**
 	 * Flag that indicates if an affected_rows value


### PR DESCRIPTION
Retrieves the affected_rows from the connection before the early close and store for retrieval