### PR TITLE
Fixes #1218 Oracle default_value needs to be trimmed in metaColumns

### DIFF
--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -181,7 +181,7 @@ END;
 			}
 			$fld->not_null = $rs->fields[5] == 'N';
 			$fld->binary = (strpos($fld->type,'BLOB') !== false);
-			$fld->default_value = $rs->fields[6];
+			$fld->default_value = trim($rs->fields[6] ?? '');
 
 			if ($ADODB_FETCH_MODE == ADODB_FETCH_NUM) {
 				$retarr[] = $fld;


### PR DESCRIPTION
Removes trailing spaces from default value ensuring correct null value handling