### PR TITLE
Fixes #1220 oci8 MetaTables should return false, not an empty array for an empty result

### DIFF
--- a/drivers/adodb-oci8.inc.php
+++ b/drivers/adodb-oci8.inc.php
@@ -489,6 +489,10 @@ END;
 		}
 		$ret = ADOConnection::MetaTables($ttype,$showSchema);
 
+		if (!$ret || is_array($ret) && count($ret) == 0) {
+			$ret = false;
+		}
+
 		if ($mask) {
 			$this->metaTablesSQL = $save;
 		}


### PR DESCRIPTION
MetaTables should return false, not an empty array for an empty result