### PR TITLE
Fix Active Record case sensitivity on PHP 8.x with UPPERCASE columns

### DIFF
--- a/adodb-active-record.inc.php
+++ b/adodb-active-record.inc.php
@@ -142,7 +142,7 @@ class ADODB_Active_Record
 
 	public function __set($name, $value)
 	{
-		$name = str_replace(' ', '_', $name);
+		$name = strtolower(str_replace(' ', '_', $name));
 		$this->$name = $value;
 	}
 
@@ -886,7 +886,8 @@ class ADODB_Active_Record
 		$valstr = array();
 
 		foreach ($table->flds as $name => $fld) {
-			$val = $this->$name;
+			$propname = strtolower($name);
+			$val = $this->$propname;
 			if(!is_array($val) || !array_key_exists($name, $table->keys)) {
 				$valarr[] = $val;
 				$names[] = $this->nameQuoter($db, $name);
@@ -981,7 +982,8 @@ class ADODB_Active_Record
 		$pkey = $table->keys;
 
 		foreach ($table->flds as $name => $fld) {
-			$val = $this->$name;
+			$propname = strtolower($name);
+			$val = $this->$propname;
 			/*
 			if (is_null($val)) {
 				if (isset($fld->not_null) && $fld->not_null) {
@@ -1082,7 +1084,8 @@ class ADODB_Active_Record
 		$cnt = 0;
 		foreach ($table->flds as $name => $fld) {
 			$orig = $this->_original[$i++] ?? null;
-			$val = $this->$name;
+			$propname = strtolower($name);
+			$val = $this->$propname;
 			$neworig[] = $val;
 
 			if (isset($table->keys[$name]) || is_array($val)) {


### PR DESCRIPTION
## Summary
- Fix Active Record `Insert()`, `Replace()`, and `Update()` producing all-null bind values when MySQL/MariaDB returns UPPERCASE column names in table metadata
- Normalize property names to lowercase in `__set()` for consistent access
- Read properties using `strtolower($name)` in Insert/Replace/Update methods

## Problem
When MySQL returns UPPERCASE column names (e.g. `STAFFNO`, `ITMCODE`), the Active Record methods access `$this->STAFFNO` but user code sets `$record->staffno`. On PHP 8.x, `$this->$name` does not go through `__get`/`__set` when called from within the class, so UPPERCASE property names resolve to undefined/null.

This causes:
```
INSERT INTO table (STAFFNO,...) VALUES (?,?) -- all bind values are null
Column 'STAFFNO' cannot be null
```

## Root Cause
- `__set()` stores properties as-is (lowercase from user code)
- `Insert()`/`Update()` iterate `$table->flds` which has UPPERCASE keys from MySQL metadata
- `$this->$name` (UPPERCASE) != `$this->$name` (lowercase) in PHP 8.x

## Fix
1. `__set()`: normalize name to lowercase via `strtolower()`
2. `Insert()`, `Replace()`, `Update()`: use `strtolower($name)` when reading property values

## Test plan
- [x] Tested with PHP 8.3.20, MySQL/MariaDB, UPPERCASE column names
- [x] Active Record `Save()` (INSERT) works with compound primary keys
- [x] Active Record `Save()` (UPDATE) works for existing records
- [x] Backward compatible — lowercase column names continue to work