### PR TITLE
fixes #1233 | Restored previous return value semantics of AutoExecute

### DIFF
--- a/adodb.inc.php
+++ b/adodb.inc.php
@@ -2685,9 +2685,12 @@ if (!defined('_ADODB_LAYER')) {
 		}
 
 		$rs = $this->SelectLimit($sql, 1);
-		if (!$rs || $mode == DB_AUTOQUERY_UPDATE && $rs->EOF) {
-			// Table does not exist or udpate where clause matches no rows
+		if (!$rs) {
+			// Table does not exist
 			return false;
+		} elseif ($mode == DB_AUTOQUERY_UPDATE && $rs->EOF) {
+			// where clause for update matches no rows, we can abort early
+			return true;
 		}
 
 		$rs->tableName = $table;


### PR DESCRIPTION
retaining the early return when no rows would be updated.

See #1233 for discussions.

fixes #1233